### PR TITLE
Package jul-to-slf4j in fat jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -391,6 +391,7 @@
                   <include>org.bouncycastle*:*</include>
                   <include>org.lz4*:*</include>
                   <include>commons-collections:commons-collections</include>
+                  <include>org.slf4j:jul-to-slf4j</include>
                 </includes>
               </artifactSet>
               <filters>


### PR DESCRIPTION
Unlike Spark, Flink doesn't ship with this jar in its `lib/`.