### PR TITLE
[Catalog] Fix table schema upload for single field table

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,13 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-table-common</artifactId>
+      <version>${flink.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- A planner dependency won't be necessary once FLIP-32 has been completed. -->
     <dependency>
       <groupId>org.apache.flink</groupId>

--- a/src/main/scala/org/apache/flink/table/catalog/pulsar/PulsarCatalog.scala
+++ b/src/main/scala/org/apache/flink/table/catalog/pulsar/PulsarCatalog.scala
@@ -21,6 +21,7 @@ import scala.collection.JavaConverters._
 import org.apache.flink.streaming.connectors.pulsar.PulsarTableSourceSinkFactory
 import org.apache.flink.streaming.connectors.pulsar.internal.{PulsarMetadataReader, PulsarOptions}
 import org.apache.flink.table.catalog.{AbstractCatalog, CatalogBaseTable, CatalogDatabase, CatalogDatabaseImpl, CatalogFunction, CatalogPartition, CatalogPartitionSpec, CatalogTableImpl, ObjectPath}
+import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException
 import org.apache.flink.table.catalog.stats.{CatalogColumnStatistics, CatalogTableStatistics}
 import org.apache.flink.table.factories.TableFactory
 
@@ -96,6 +97,12 @@ class PulsarCatalog(
     tablePath: ObjectPath,
     table: CatalogBaseTable,
     ignoreIfExists: Boolean): Unit = {
+
+    val tableAlreadyExist = tableExists(tablePath)
+    if (tableAlreadyExist) {
+      if (ignoreIfExists) return
+      else throw new TableAlreadyExistException(getName, tablePath)
+    }
 
     val defaultNumPartitions = properties.getOrDefault(PulsarOptions.NUM_PARTITIONS, "5").toInt
 

--- a/src/test/scala/org/apache/flink/streaming/connectors/pulsar/CatalogITest.scala
+++ b/src/test/scala/org/apache/flink/streaming/connectors/pulsar/CatalogITest.scala
@@ -241,7 +241,7 @@ class CatalogITest extends PulsarFunSuite with PulsarFlinkTest {
 
     tableEnv1.useCatalog("pulsarcatalog1")
 
-    val t = tableEnv1.scan("tableSink").select("v")
+    val t = tableEnv1.scan("tableSink").select("value")
 
     val tpe = t.getSchema.toRowType
 

--- a/src/test/scala/org/apache/flink/streaming/connectors/pulsar/CatalogITest.scala
+++ b/src/test/scala/org/apache/flink/streaming/connectors/pulsar/CatalogITest.scala
@@ -262,7 +262,8 @@ class CatalogITest extends PulsarFunSuite with PulsarFlinkTest {
     reader.start()
 
     reader.join()
-    assert(StreamITCase.testResults === int32Seq.init.map(_.toString))
+    assert(StreamITCase.testResults.toSet === int32Seq.init.map(_.toString).toSet)
+
   }
 
   test("sink to existing topic") {

--- a/src/test/scala/org/apache/flink/streaming/connectors/pulsar/internals/PulsarFlinkTest.scala
+++ b/src/test/scala/org/apache/flink/streaming/connectors/pulsar/internals/PulsarFlinkTest.scala
@@ -70,12 +70,20 @@ trait PulsarFlinkTest extends PulsarTest {
   def waitUntilNoJobIsRunning(client: ClusterClient[_]): Unit = {
     while (!getRunningJobs(client).isEmpty) {
       Thread.sleep(50)
+      cancelRunningJobs(client)
     }
   }
 
   def getRunningJobs(client: ClusterClient[_]): Seq[JobID] = {
     val statusMessages= client.listJobs.get
     statusMessages.asScala.filter(!_.getJobState.isGloballyTerminalState).map(_.getJobId).toSeq
+  }
+
+  def cancelRunningJobs(client: ClusterClient[_]): Unit = {
+    val runningJobs = getRunningJobs(client)
+    runningJobs.foreach { job =>
+      client.cancel(job)
+    }
   }
 
 }


### PR DESCRIPTION
## BUG Fixed

Two bugs are fixed in this PR:
- create an existing table should report TableAlreadyExistException when `ignoreIfExists` is false.
- in FlinkPulsarRowSink, metadata fields shouldn't write to message's value part


## Limitations

- for pulsar primitive schema, when we have created a table with
```
create table person(int age);
```
we would create a pulsar topic of `SchemaType.INT32`, however, `person`'s field name after creation would be lost, i.e. we could only use `value` instead fo the original `age`:
```
select value from person;
```

- During the data sink, a validation exists to check if the result type of a query is identical to the topic to sink to. And the topic schema is inferred by us (including metadata fields), therefore, we cannot insert a single field table into our primitive type topic:

```
create table abc(int age);
create table cde(int age);
insert into cde select age from abc; // validation failed since cde have schema of `value, __messageId .....` and select age have schema of int
```