### PR TITLE
Various fixes for build, admin, and multiple schema sink

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <groupId>io.streamnative.connectors</groupId>
   <artifactId>pulsar-flink-connector_${scala.binary.version}</artifactId>
-  <version>2.4.0</version>
+  <version>2.4.1</version>
   <name>StreamNative :: Pulsar Flink Connector</name>
   <url>http://pulsar.apache.org</url>
   <inceptionYear>2019</inceptionYear>
@@ -95,7 +95,7 @@
 
     <dependency>
       <groupId>org.json4s</groupId>
-      <artifactId>json4s-jackson_2.11</artifactId>
+      <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
       <version>3.6.7</version>
     </dependency>
 
@@ -456,6 +456,18 @@
           <execution>
             <goals>
               <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
             </goals>
           </execution>
         </executions>

--- a/src/main/scala/org/apache/flink/streaming/connectors/pulsar/internal/PulsarOptions.scala
+++ b/src/main/scala/org/apache/flink/streaming/connectors/pulsar/internal/PulsarOptions.scala
@@ -24,6 +24,11 @@ object PulsarOptions {
   val PULSAR_CONSUMER_OPTION_KEY_PREFIX = "pulsar.consumer."
   val PULSAR_READER_OPTION_KEY_PREFIX = "pulsar.reader."
 
+  // auth options
+  val PULSAR_CLIENT_AUTH_PLUGIN_KEY = PULSAR_CLIENT_OPTION_KEY_PREFIX + "authPluginClassName"
+  val PULSAR_CLIENT_AUTH_PARAMS_KEY = PULSAR_CLIENT_OPTION_KEY_PREFIX + "authParams"
+  val PULSAR_CLIENT_TLS_CERT_PATH = PULSAR_CLIENT_OPTION_KEY_PREFIX + "tlsTrustCertsFilePath"
+
   // options
 
   val TOPIC_SINGLE = "topic"
@@ -32,11 +37,7 @@ object PulsarOptions {
 
   val PARTITION_SUFFIX = TopicName.PARTITIONED_TOPIC_SUFFIX
 
-  val TOPIC_OPTION_KEYS = Set(
-    TOPIC_SINGLE,
-    TOPIC_MULTI,
-    TOPIC_PATTERN
-  )
+  val TOPIC_OPTION_KEYS = Set(TOPIC_SINGLE, TOPIC_MULTI, TOPIC_PATTERN)
 
   val SERVICE_URL_OPTION_KEY = "service.url"
   val ADMIN_URL_OPTION_KEY = "admin.url"


### PR DESCRIPTION
This commit makes a few primary changes:
- makes a few build fixes, this is primarily so I can build against
scala 2.12 (not in this commit, will see if I can get that in a profile)
- adds auth and TLS support to the admin client, currently, it isn't
authenticated
- tweaks the sink to allow for producing into multiple topics with
different schemas. This isn't supported natively by the higher level Row
and Sink classes, but can now be done by extend in the SinkBase
- some minor formatting changes (done by scalafmt), I didn't realize it
was formatting in this project, but they mostly seem to be improvements,
so figured I would keep it