### PR TITLE
Use external subscription

### DIFF
--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarRowSource.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarRowSource.java
@@ -87,6 +87,6 @@ public class FlinkPulsarRowSource extends FlinkPulsarSource<Row> {
                 readerConf,
                 pollTimeoutMs,
                 null,
-                topicDiscoverer);
+				metadataReader);
     }
 }

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSource.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSource.java
@@ -737,6 +737,7 @@ public class FlinkPulsarSource<T>
                 for (String topic : topics) {
                     offsetsFromSubs.put(topic, metadataReader.getPositionFromSubscription(topic, MessageId.latest));
                 }
+                return offsetsFromSubs;
         }
         return null;
     }

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSource.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSource.java
@@ -124,6 +124,12 @@ public class FlinkPulsarSource<T>
     /** Specific startup offsets; only relevant when startup mode is {@link StartupMode#SPECIFIC_OFFSETS}. */
     private transient Map<String, MessageId> specificStartupOffsets;
 
+    /** The subscription name to be used; only relevant when startup mode is {@link StartupMode#EXTERNAL_SUBSCRIPTION}
+     * If the subscription exists for a partition, we would start reading this partition from the subscription cursor.
+     * At the same time, checkpoint for the job would made progress on the subscription.
+     */
+    private String externalSubscriptionName;
+
     // TODO: remove this when MessageId is serializable itself.
     // see: https://github.com/apache/pulsar/pull/6064
     private Map<String, byte[]> specificStartupOffsetsAsBytes;
@@ -143,7 +149,7 @@ public class FlinkPulsarSource<T>
     private transient volatile PulsarFetcher<T> pulsarFetcher;
 
     /** The partition discoverer, used to find new partitions. */
-    protected transient volatile PulsarMetadataReader topicDiscoverer;
+    protected transient volatile PulsarMetadataReader metadataReader;
 
     /**
      * The offsets to restore to, if the consumer restores state from a checkpoint.
@@ -317,6 +323,12 @@ public class FlinkPulsarSource<T>
         return this;
     }
 
+    public FlinkPulsarSource<T> setStartFromSubscription(String externalSubscriptionName) {
+        this.startupMode = StartupMode.EXTERNAL_SUBSCRIPTION;
+        this.externalSubscriptionName = checkNotNull(externalSubscriptionName);
+        return this;
+    }
+
 
     // ------------------------------------------------------------------------
     //  Work methods
@@ -328,10 +340,10 @@ public class FlinkPulsarSource<T>
         this.taskIndex = getRuntimeContext().getIndexOfThisSubtask();
         this.numParallelTasks = getRuntimeContext().getNumberOfParallelSubtasks();
 
-        this.topicDiscoverer = createTopicDiscoverer();
+        this.metadataReader = createMetadataReader();
 
         ownedTopicStarts = new HashMap<>();
-        Set<String> allTopics = topicDiscoverer.discoverTopicChanges();
+        Set<String> allTopics = metadataReader.discoverTopicChanges();
 
         if (restoredState != null) {
             allTopics.stream()
@@ -377,17 +389,23 @@ public class FlinkPulsarSource<T>
         }
     }
 
-    protected String getSubscriptionPrefix() {
-        return "flink-pulsar-" + uuid.toString();
+    protected String getSubscriptionName() {
+        if (startupMode == StartupMode.EXTERNAL_SUBSCRIPTION) {
+            checkNotNull(externalSubscriptionName);
+            return externalSubscriptionName;
+        } else {
+            return "flink-pulsar-" + uuid.toString();
+        }
     }
 
-    protected PulsarMetadataReader createTopicDiscoverer() throws PulsarClientException {
+    protected PulsarMetadataReader createMetadataReader() throws PulsarClientException {
         return new PulsarMetadataReader(
                 adminUrl,
-                getSubscriptionPrefix(),
+                getSubscriptionName(),
                 caseInsensitiveParams,
                 taskIndex,
-                numParallelTasks);
+                numParallelTasks,
+                startupMode == StartupMode.EXTERNAL_SUBSCRIPTION);
     }
 
     @Override
@@ -474,7 +492,7 @@ public class FlinkPulsarSource<T>
                 readerConf,
                 pollTimeoutMs,
                 deserializer,
-                topicDiscoverer);
+                metadataReader);
     }
 
     public void joinDiscoveryLoopThread() throws InterruptedException {
@@ -502,7 +520,7 @@ public class FlinkPulsarSource<T>
                 () -> {
                     try {
                         while (running) {
-                            Set<String> added = topicDiscoverer.discoverTopicChanges();
+                            Set<String> added = metadataReader.discoverTopicChanges();
 
                             if (running && !added.isEmpty()) {
                                 pulsarFetcher.addDiscoveredTopics(added);
@@ -537,9 +555,9 @@ public class FlinkPulsarSource<T>
 
         Exception exception = null;
 
-        if (topicDiscoverer != null) {
+        if (metadataReader != null) {
             try {
-                topicDiscoverer.close();
+                metadataReader.close();
             } catch (Exception e) {
                 exception = e;
             }
@@ -714,6 +732,11 @@ public class FlinkPulsarSource<T>
                     }
                 }
                 return specificOffsets;
+            case EXTERNAL_SUBSCRIPTION:
+                Map<String, MessageId> offsetsFromSubs = new HashMap<>();
+                for (String topic : topics) {
+                    offsetsFromSubs.put(topic, metadataReader.getPositionFromSubscription(topic, MessageId.latest));
+                }
         }
         return null;
     }

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/PulsarTableSource.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/PulsarTableSource.java
@@ -67,6 +67,8 @@ public class PulsarTableSource
 
     private final Map<String, MessageId> specificStartupOffsets;
 
+    private final String externalSubscriptionName;
+
     private final Map<String, String> caseInsensitiveParams;
 
     private final Optional<TableSchema> providedSchema;
@@ -84,7 +86,8 @@ public class PulsarTableSource
             String adminUrl,
             Properties properties,
             StartupMode startupMode,
-            Map<String, MessageId> specificStartupOffsets) {
+            Map<String, MessageId> specificStartupOffsets,
+            String externalSubscriptionName) {
 
         this.providedSchema = providedSchema;
         this.serviceUrl = checkNotNull(serviceUrl);
@@ -92,6 +95,7 @@ public class PulsarTableSource
         this.properties = checkNotNull(properties);
         this.startupMode = startupMode;
         this.specificStartupOffsets = specificStartupOffsets;
+        this.externalSubscriptionName = externalSubscriptionName;
 
         this.caseInsensitiveParams =
                 SourceSinkUtils.validateStreamSourceOptions(Maps.fromProperties(properties));
@@ -114,7 +118,8 @@ public class PulsarTableSource
                 adminUrl,
                 properties,
                 StartupMode.LATEST,
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                null);
     }
 
     @Override
@@ -150,6 +155,8 @@ public class PulsarTableSource
             case SPECIFIC_OFFSETS:
                 source.setStartFromSpecificOffsets(specificStartupOffsets);
                 break;
+            case EXTERNAL_SUBSCRIPTION:
+                source.setStartFromSubscription(externalSubscriptionName);
         }
 
         return execEnv.addSource(source).name(explainSource());

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/config/StartupMode.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/config/StartupMode.java
@@ -23,5 +23,7 @@ public enum StartupMode {
 
     LATEST,
 
-    SPECIFIC_OFFSETS
+    SPECIFIC_OFFSETS,
+
+    EXTERNAL_SUBSCRIPTION
 }

--- a/src/main/java/org/apache/flink/table/descriptors/Pulsar.java
+++ b/src/main/java/org/apache/flink/table/descriptors/Pulsar.java
@@ -59,6 +59,8 @@ public class Pulsar extends ConnectorDescriptor {
 
     private Map<String, MessageId> specificOffsets;
 
+    private String externalSubscriptionName;
+
     private Map<String, String> pulsarProperties;
 
     private String sinkExtractorType;
@@ -143,6 +145,12 @@ public class Pulsar extends ConnectorDescriptor {
             this.specificOffsets = new HashMap<>();
         }
         this.specificOffsets.put(partition, specificOffset);
+        return this;
+    }
+
+    public Pulsar startFromExternalSubscription(String externalSubscriptionName) {
+        this.startupMode = StartupMode.EXTERNAL_SUBSCRIPTION;
+        this.externalSubscriptionName = externalSubscriptionName;
         return this;
     }
 

--- a/src/main/java/org/apache/flink/table/descriptors/PulsarValidator.java
+++ b/src/main/java/org/apache/flink/table/descriptors/PulsarValidator.java
@@ -39,9 +39,11 @@ public class PulsarValidator extends ConnectorDescriptorValidator {
     public static final String CONNECTOR_STARTUP_MODE_VALUE_EARLIEST = "earliest";
     public static final String CONNECTOR_STARTUP_MODE_VALUE_LATEST = "latest";
     public static final String CONNECTOR_STARTUP_MODE_VALUE_SPECIFIC_OFFSETS = "specific-offsets";
+    public static final String CONNECTOR_STARTUP_MODE_VALUE_EXETERNAL_SUB = "external-subscription";
     public static final String CONNECTOR_SPECIFIC_OFFSETS = "connector.specific-offsets";
     public static final String CONNECTOR_SPECIFIC_OFFSETS_PARTITION = "partition";
     public static final String CONNECTOR_SPECIFIC_OFFSETS_OFFSET = "offset";
+    public static final String CONNECTOR_EXTERNAL_SUB_NAME = "connector.sub-name";
 
     public static final String CONNECTOR_PROPERTIES = "connector.properties";
     public static final String CONNECTOR_PROPERTIES_KEY = "key";

--- a/src/test/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarITest.java
+++ b/src/test/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarITest.java
@@ -1198,7 +1198,7 @@ public class FlinkPulsarITest extends PulsarTestBaseWithFlink {
         }
 
         @Override
-        protected String getSubscriptionPrefix() {
+        protected String getSubscriptionName() {
             return "flink-pulsar-" + sub;
         }
     }

--- a/src/test/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSourceTest.java
+++ b/src/test/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSourceTest.java
@@ -600,7 +600,7 @@ public class FlinkPulsarSourceTest extends TestLogger {
         }
 
         @Override
-        protected PulsarMetadataReader createTopicDiscoverer() throws PulsarClientException {
+        protected PulsarMetadataReader createMetadataReader() throws PulsarClientException {
             return discoverer;
         }
     }
@@ -649,7 +649,7 @@ public class FlinkPulsarSourceTest extends TestLogger {
         }
 
         @Override
-        protected PulsarMetadataReader createTopicDiscoverer() throws PulsarClientException {
+        protected PulsarMetadataReader createMetadataReader() throws PulsarClientException {
             return discoverer;
         }
     }


### PR DESCRIPTION
W/o this PR, we use the subscription to prevent Pulsar delete messages that would be later used by Flink job (during failure recovery).

W/ this PR, we can use external subscription to recognize the start offset for the job (from the sub cursor), move the subscription cursor position to track successful checkpointed messages, and preserve the position after the job have been closed.

Note: the subscription provided should not be used by other consumers or the exactly-once semantics of processing would be lost.