### PR TITLE
Enable auth for data streams

### DIFF
--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarRowSource.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarRowSource.java
@@ -30,6 +30,7 @@ import org.apache.flink.util.SerializedValue;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,10 @@ public class FlinkPulsarRowSource extends FlinkPulsarSource<Row> {
 
     private TypeInformation<Row> typeInformation;
 
+    public FlinkPulsarRowSource(String adminUrl, ClientConfigurationData clientConf, Properties properties) {
+        super(adminUrl, clientConf, null, properties);
+    }
+
     public FlinkPulsarRowSource(String serviceUrl, String adminUrl, Properties properties) {
         super(serviceUrl, adminUrl, null, properties);
     }
@@ -50,7 +55,7 @@ public class FlinkPulsarRowSource extends FlinkPulsarSource<Row> {
     @Override
     public TypeInformation<Row> getProducedType() {
         if (typeInformation == null) {
-            try (PulsarMetadataReader reader = new PulsarMetadataReader(adminUrl, "", caseInsensitiveParams, -1, -1)) {
+            try (PulsarMetadataReader reader = new PulsarMetadataReader(adminUrl, clientConfigurationData, "", caseInsensitiveParams, -1, -1)) {
                 List<String> topics = reader.getTopics();
                 FieldsDataType schema = reader.getSchema(topics);
                 typeInformation = (TypeInformation<Row>) LegacyTypeInfoDataTypeConverter.toLegacyTypeInfo(schema);

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSinkBase.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSinkBase.java
@@ -23,6 +23,7 @@ import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.connectors.pulsar.internal.CachedPulsarClient;
+import org.apache.flink.streaming.connectors.pulsar.internal.PulsarAdminUtils;
 import org.apache.flink.streaming.connectors.pulsar.internal.SchemaUtils;
 import org.apache.flink.streaming.connectors.pulsar.internal.SourceSinkUtils;
 import org.apache.flink.util.ExceptionUtils;
@@ -183,7 +184,7 @@ abstract class FlinkPulsarSinkBase<T> extends RichSinkFunction<T> implements Che
             flushOnCheckpoint = false;
         }
 
-        admin = PulsarAdmin.builder().serviceHttpUrl(adminUrl).build();
+        admin = PulsarAdminUtils.newAdminFromConf(adminUrl, clientConfigurationData);
 
         if (forcedTopic) {
             uploadSchema(defaultTopic);

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSource.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSource.java
@@ -405,6 +405,7 @@ public class FlinkPulsarSource<T>
     protected PulsarMetadataReader createMetadataReader() throws PulsarClientException {
         return new PulsarMetadataReader(
                 adminUrl,
+                clientConfigurationData,
                 getSubscriptionName(),
                 caseInsensitiveParams,
                 taskIndex,

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/PulsarTableSource.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/PulsarTableSource.java
@@ -40,6 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 
 import java.util.Collections;
 import java.util.List;
@@ -167,7 +168,7 @@ public class PulsarTableSource
             return providedSchema.get();
         } else {
             try {
-                PulsarMetadataReader reader = new PulsarMetadataReader(adminUrl, "", caseInsensitiveParams, -1, -1);
+                PulsarMetadataReader reader = new PulsarMetadataReader(adminUrl, new ClientConfigurationData(), "", caseInsensitiveParams, -1, -1);
                 List<String> topics = reader.getTopics();
                 FieldsDataType schema = reader.getSchema(topics);
                 return SchemaUtils.toTableSchema(schema);

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarAdminUtils.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarAdminUtils.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.connectors.pulsar.internal;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.AuthenticationFactory;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.apache.pulsar.shade.org.apache.commons.lang3.StringUtils;
+
+/**
+ * Utility to create Pulsar Admin Client from adminUrl and clientConfigurationData.
+ */
+public class PulsarAdminUtils {
+
+	public static PulsarAdmin newAdminFromConf(String adminUrl, ClientConfigurationData clientConfigurationData) throws PulsarClientException {
+		ClientConfigurationData adminConf = clientConfigurationData.clone();
+		adminConf.setServiceUrl(adminUrl);
+		setAuth(adminConf);
+		return new PulsarAdmin(adminUrl, adminConf);
+	}
+
+	private static void setAuth(ClientConfigurationData conf) throws PulsarClientException {
+		if (!StringUtils.isBlank(conf.getAuthPluginClassName()) && !StringUtils.isBlank(conf.getAuthParams())) {
+			conf.setAuthentication(AuthenticationFactory.create(conf.getAuthPluginClassName(), conf.getAuthParams()));
+		}
+	}
+}

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarAdminUtils.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarAdminUtils.java
@@ -11,6 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.streaming.connectors.pulsar.internal;
 
 import org.apache.pulsar.client.admin.PulsarAdmin;

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarMetadataReader.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarMetadataReader.java
@@ -29,6 +29,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.schema.BytesSchema;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
@@ -79,6 +80,7 @@ public class PulsarMetadataReader implements AutoCloseable {
 
     public PulsarMetadataReader(
             String adminUrl,
+            ClientConfigurationData clientConf,
             String subscriptionName,
             Map<String, String> caseInsensitiveParams,
             int indexOfThisSubtask,
@@ -91,17 +93,18 @@ public class PulsarMetadataReader implements AutoCloseable {
         this.indexOfThisSubtask = indexOfThisSubtask;
         this.numParallelSubtasks = numParallelSubtasks;
         this.useExternalSubscription = useExternalSubscription;
-        this.admin = PulsarAdmin.builder().serviceHttpUrl(adminUrl).build();
+        this.admin = PulsarAdminUtils.newAdminFromConf(adminUrl, clientConf);
     }
 
     public PulsarMetadataReader(
             String adminUrl,
+            ClientConfigurationData clientConf,
             String subscriptionName,
             Map<String, String> caseInsensitiveParams,
             int indexOfThisSubtask,
             int numParallelSubtasks) throws PulsarClientException {
 
-        this(adminUrl, subscriptionName, caseInsensitiveParams, indexOfThisSubtask, numParallelSubtasks, false);
+        this(adminUrl, clientConf, subscriptionName, caseInsensitiveParams, indexOfThisSubtask, numParallelSubtasks, false);
     }
 
     @Override

--- a/src/main/java/org/apache/flink/table/catalog/pulsar/PulsarCatalog.java
+++ b/src/main/java/org/apache/flink/table/catalog/pulsar/PulsarCatalog.java
@@ -47,6 +47,7 @@ import org.apache.flink.table.factories.TableFactory;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 
 import java.util.HashMap;
 import java.util.List;
@@ -90,7 +91,7 @@ public class PulsarCatalog extends AbstractCatalog {
     public void open() throws CatalogException {
         if (metadataReader == null) {
             try {
-                metadataReader = new PulsarMetadataReader(adminUrl, "", new HashMap<>(), -1, -1);
+                metadataReader = new PulsarMetadataReader(adminUrl, new ClientConfigurationData(), "", new HashMap<>(), -1, -1);
             } catch (PulsarClientException e) {
                 throw new CatalogException("Failed to create Pulsar admin using " + adminUrl, e);
             }

--- a/src/test/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarITest.java
+++ b/src/test/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarITest.java
@@ -31,7 +31,6 @@ import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.runtime.client.JobCancellationException;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
-import org.apache.flink.shaded.guava18.com.google.common.collect.Sets;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
@@ -58,6 +57,7 @@ import org.apache.flink.util.Collector;
 import org.apache.flink.util.ExceptionUtils;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
+import org.apache.flink.shaded.guava18.com.google.common.collect.Sets;
 
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;

--- a/src/test/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSourceTest.java
+++ b/src/test/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSourceTest.java
@@ -59,6 +59,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.common.naming.TopicName;
 import org.junit.Assert;
 import org.junit.Test;
@@ -498,7 +499,7 @@ public class FlinkPulsarSourceTest extends TestLogger {
         private final RuntimeException failureCause;
 
         public FailingPartitionDiscoverer(RuntimeException failureCause) throws PulsarClientException {
-            super("", "", Collections.singletonMap("topic", "foo"), 0, 1);
+            super("", new ClientConfigurationData(), "", Collections.singletonMap("topic", "foo"), 0, 1);
             this.failureCause = failureCause;
         }
 
@@ -528,7 +529,7 @@ public class FlinkPulsarSourceTest extends TestLogger {
         private static Set<String> allPartitions = Sets.newHashSet("foo");
 
         public DummyPartitionDiscoverer() throws PulsarClientException {
-            super("", "", Collections.singletonMap("topic", "foo"), 0, 1);
+            super("", new ClientConfigurationData(), "", Collections.singletonMap("topic", "foo"), 0, 1);
         }
 
         @Override

--- a/src/test/java/org/apache/flink/streaming/connectors/pulsar/internal/CachedPulsarClientTest.java
+++ b/src/test/java/org/apache/flink/streaming/connectors/pulsar/internal/CachedPulsarClientTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentMap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit test of {@link CachedPulsarClient}.
@@ -36,6 +37,18 @@ public class CachedPulsarClientTest {
     @Before
     public void clearCache() {
         CachedPulsarClient.clear();
+    }
+
+    @Test
+    public void testClientConfClone() {
+        ClientConfigurationData conf1 = new ClientConfigurationData();
+        conf1.setTlsTrustCertsFilePath("abc");
+        ClientConfigurationData conf2 = conf1.clone();
+        conf2.setTlsTrustCertsFilePath("def");
+
+        assertTrue(conf1 != conf2);
+        assertEquals(conf1.getTlsTrustCertsFilePath(), "abc");
+        assertEquals(conf2.getTlsTrustCertsFilePath(), "def");
     }
 
     @Test

--- a/src/test/java/org/apache/flink/streaming/connectors/pulsar/testutils/TestMetadataReader.java
+++ b/src/test/java/org/apache/flink/streaming/connectors/pulsar/testutils/TestMetadataReader.java
@@ -17,6 +17,7 @@ package org.apache.flink.streaming.connectors.pulsar.testutils;
 import org.apache.flink.streaming.connectors.pulsar.internal.PulsarMetadataReader;
 
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.mockito.stubbing.Answer;
 
 import java.util.List;
@@ -41,7 +42,7 @@ public class TestMetadataReader extends PulsarMetadataReader {
             int indexOfThisSubtask,
             int numParallelSubtasks,
             List<Set<String>> mockGetAllTopicsReturnSequence) throws PulsarClientException {
-        super("", "", caseInsensitiveParams, indexOfThisSubtask, numParallelSubtasks);
+        super("", new ClientConfigurationData(), "", caseInsensitiveParams, indexOfThisSubtask, numParallelSubtasks);
         this.mockGetAllTopicsReturnSequence = mockGetAllTopicsReturnSequence;
     }
 


### PR DESCRIPTION
This PR enables to connect to authentication-enabled Pulsar instance in DataStream API.

The Table API and catalog API changes will be added in a separate PR.

