### PR TITLE
flink checkpoint abort when source parallelism is greater than topic partition number

### DIFF
--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
@@ -268,14 +268,12 @@ public class PulsarFetcher<T> {
                 }
 
                 if (topicToThread.size() == 0 && unassignedPartitionsQueue.isEmpty()) {
-                    while (running) {
-                        PulsarTopicState topicForBlocking = unassignedPartitionsQueue.getElementBlocking();
-                        if (!topicForBlocking.equals(PoisonState.INSTANCE)) {
-                            topicToThread.putAll(
-                                createAndStartReaderThread(ImmutableList.of(topicForBlocking), exceptionProxy));
-                            break;
-                        }
+                    PulsarTopicState topicForBlocking = unassignedPartitionsQueue.getElementBlocking();
+                    if (topicForBlocking.equals(PoisonState.INSTANCE)) {
+                        throw BreakingException.INSTANCE;
                     }
+                    topicToThread.putAll(
+                            createAndStartReaderThread(ImmutableList.of(topicForBlocking), exceptionProxy));
                 }
             }
 

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
@@ -267,8 +267,11 @@ public class PulsarFetcher<T> {
 
                 }
 
-                PulsarTopicState topicForBlocking = unassignedPartitionsQueue.getElementBlocking();
-                topicToThread.putAll(createAndStartReaderThread(ImmutableList.of(topicForBlocking), exceptionProxy));
+                if (topicToThread.size() == 0 && unassignedPartitionsQueue.isEmpty()) {
+                    PulsarTopicState topicForBlocking = unassignedPartitionsQueue.getElementBlocking();
+                    topicToThread.putAll(
+                        createAndStartReaderThread(ImmutableList.of(topicForBlocking), exceptionProxy));
+                }
             }
 
         } catch (BreakingException b) {

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
@@ -28,6 +28,7 @@ import org.apache.flink.util.SerializedValue;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.apache.pulsar.shade.com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -36,7 +37,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
-import org.apache.pulsar.shade.com.google.common.collect.ImmutableList;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
+import org.apache.pulsar.shade.com.google.common.collect.ImmutableList;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -266,13 +267,8 @@ public class PulsarFetcher<T> {
 
                 }
 
-                if (topicToThread.size() == 0 && unassignedPartitionsQueue.isEmpty()) {
-                    if (unassignedPartitionsQueue.close()) {
-                        log.info("All reader threads are finished, " +
-                                "there are no more unassigned partitions. Stopping fetcher");
-                        throw BreakingException.INSTANCE;
-                    }
-                }
+                PulsarTopicState topicForBlocking = unassignedPartitionsQueue.getElementBlocking();
+                topicToThread.putAll(createAndStartReaderThread(ImmutableList.of(topicForBlocking), exceptionProxy));
             }
 
         } catch (BreakingException b) {

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
@@ -268,9 +268,14 @@ public class PulsarFetcher<T> {
                 }
 
                 if (topicToThread.size() == 0 && unassignedPartitionsQueue.isEmpty()) {
-                    PulsarTopicState topicForBlocking = unassignedPartitionsQueue.getElementBlocking();
-                    topicToThread.putAll(
-                        createAndStartReaderThread(ImmutableList.of(topicForBlocking), exceptionProxy));
+                    while (running) {
+                        PulsarTopicState topicForBlocking = unassignedPartitionsQueue.getElementBlocking();
+                        if (!topicForBlocking.equals(PoisonState.INSTANCE)) {
+                            topicToThread.putAll(
+                                createAndStartReaderThread(ImmutableList.of(topicForBlocking), exceptionProxy));
+                            break;
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
### flink checkpoint abort when source parallelism is greater than topic partition number
In the pulsar-flink code implementation, if the source parallelism is greater than topic partition number, the task will be changed to `FINISHED` state. 
When flink checkpoint coordinator startting to do checkpoint, it found the `FINISHED` state tasks, the checkpoint will be aborted. 
The error log is as follow:
```
2020-02-28 15:35:47,771 INFO  org.apache.flink.runtime.checkpoint.CheckpointCoordinator     - Discarding checkpoint 4 of job 3293a239d654f02b0c02c4c95b8c424c.
org.apache.flink.runtime.checkpoint.CheckpointException: Task NameSource: Custom Source -> Flat Map (4/5) Failure reason: Checkpoint was declined (tasks not ready)
	at org.apache.flink.runtime.taskmanager.Task$1.run(Task.java:1158)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
2020-02-28 15:35:47,772 DEBUG org.apache.flink.runtime.checkpoint.CheckpointCoordinator     - Received another decline message for now expired checkpoint attempt 4 from task f8ac9d371546fa51c5fdfc073a69fb1e of job 3293a239d654f02b0c02c4c95b8c424c at container_e11_1582541337032_0026_01_000003 @ localhost (dataPort=39776) : Task NameSource: Custom Source -> Flat Map (3/5) Failure reason: Checkpoint was declined (tasks not ready)
2020-02-28 15:35:47,772 DEBUG org.apache.flink.runtime.checkpoint.CheckpointCoordinator     - Received another decline message for now expired checkpoint attempt 4 from task abb129963220530a4f78ea05b497d606 of job 3293a239d654f02b0c02c4c95b8c424c at container_e11_1582541337032_0026_01_000002 @ localhost (dataPort=53945) : Task received cancellation from one of its inputs
2020-02-28 15:35:47,909 DEBUG org.apache.flink.runtime.checkpoint.CheckpointCoordinator     - Received another decline message for now expired checkpoint attempt 4 from task 25f6c6b094a0262372424e8045359df3 of job 3293a239d654f02b0c02c4c95b8c424c at container_e11_1582541337032_0026_01_000004 @ localhost (dataPort=53812) : Task NameSource: Custom Source -> Flat Map (5/5) Failure reason: Checkpoint was declined (tasks not ready)
2020-02-28 15:35:47,971 DEBUG org.apache.flink.runtime.checkpoint.CheckpointCoordinator     - Received another decline message for now expired checkpoint attempt 4 from task 933e15126f6f26154bfba5a27340a393 of job 3293a239d654f02b0c02c4c95b8c424c at container_e11_1582541337032_0026_01_000005 @ localhost (dataPort=33860) : Task NameSource: Custom Source -> Flat Map (1/5) Failure reason: Checkpoint was declined (tasks not ready)
2020-02-28 15:35:48,044 DEBUG org.apache.flink.runtime.checkpoint.CheckpointCoordinator     - Received another decline message for now expired checkpoint attempt 4 from task dccb3e2b2645ed1f0bcc13abe9abf70d of job 3293a239d654f02b0c02c4c95b8c424c at container_e11_1582541337032_0026_01_000002 @ localhost (dataPort=53945) : Could not materialize checkpoint 4 for operator Source: Custom Source -> Flat Map (2/5).
```