### PR TITLE
Use equals while comparing latest and earliest

### DIFF
--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
@@ -469,7 +469,7 @@ public class PulsarFetcher<T> {
         Map<String, MessageId> result = new HashMap<>();
         for (Map.Entry<String, MessageId> entry : offset.entrySet()) {
             MessageId mid = entry.getValue();
-            if (mid != MessageId.earliest && mid != MessageId.latest) {
+            if (!mid.equals(MessageId.earliest) && !mid.equals(MessageId.latest)) {
                 result.put(entry.getKey(), mid);
             }
         }

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/ReaderThread.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/ReaderThread.java
@@ -116,7 +116,7 @@ public class ReaderThread<T> extends Thread {
     protected void skipFirstMessageIfNeeded() throws org.apache.pulsar.client.api.PulsarClientException {
         Message<?> currentMessage;
         MessageId currentId;
-        if (startMessageId != MessageId.earliest && startMessageId != MessageId.latest) {
+        if (!startMessageId.equals(MessageId.earliest) && !startMessageId.equals(MessageId.latest)) {
             currentMessage = reader.readNext(pollTimeoutMs, TimeUnit.MILLISECONDS);
             if (currentMessage == null) {
                 reportDataLoss(String.format("Cannot read data at offset %s from topic: %s",


### PR DESCRIPTION
Since messageId could be recovered from state or deserialized from bytes when specific starting offsets option is used, it is always safe to compare equality of actual object.