### PR TITLE
Avoid skipping the non-existence message

### DIFF
--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarMetadataReader.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarMetadataReader.java
@@ -283,9 +283,13 @@ public class PulsarMetadataReader implements AutoCloseable {
                             admin.topics().getInternalStats(topic).cursors.get(subscriptionName);
                     String[] ids = c.markDeletePosition.split(":", 2);
                     long ledgerId = Long.parseLong(ids[0]);
-                    long entryId = Long.parseLong(ids[1]);
+                    long entryIdInMarkDelete = Long.parseLong(ids[1]);
+                    // we are getting the next mid from sub position, if the entryId is -1,
+                    // it denotes we haven't read data from the ledger before,
+                    // therefore no need to skip the current entry for the next position
+                    long entryId = entryIdInMarkDelete == -1 ? -1 : entryIdInMarkDelete + 1;
                     int partitionIdx = TopicName.getPartitionIndex(topic);
-                    return new MessageIdImpl(ledgerId, entryId + 1, partitionIdx);
+                    return new MessageIdImpl(ledgerId, entryId, partitionIdx);
                 }
             } else {
                 // create sub on topic

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/ReaderThread.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/ReaderThread.java
@@ -116,7 +116,9 @@ public class ReaderThread<T> extends Thread {
     protected void skipFirstMessageIfNeeded() throws org.apache.pulsar.client.api.PulsarClientException {
         Message<?> currentMessage;
         MessageId currentId;
-        if (!startMessageId.equals(MessageId.earliest) && !startMessageId.equals(MessageId.latest)) {
+        if (!startMessageId.equals(MessageId.earliest)
+                && !startMessageId.equals(MessageId.latest)
+                && ((MessageIdImpl) startMessageId).getEntryId() != -1) {
             currentMessage = reader.readNext(pollTimeoutMs, TimeUnit.MILLISECONDS);
             if (currentMessage == null) {
                 reportDataLoss(String.format("Cannot read data at offset %s from topic: %s",


### PR DESCRIPTION
If we get the messageId from subscription's `markDelete` position, we should avoid skipping the non-existence message when the messageId has `entryId` of -1.