### PR TITLE
Update jackson-databind version to 2.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
     <streamnative-tests.version>2.4.2</streamnative-tests.version>
     <testcontainers.version>1.10.6</testcontainers.version>
     <hamcrest.version>1.3</hamcrest.version>
+    <jackson.version>2.10.1</jackson.version>
     <!-- plugin dependencies -->
     <maven.version>3.5.4</maven.version>
     <license-maven-plugin.version>3.0.rc1</license-maven-plugin.version>
@@ -96,7 +97,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.10.4</version>
+      <version>${jackson.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Fix issue https://github.com/streamnative/mono-repo/issues/381

# Motivation

Update the dependency jar `com.fasterxml.jackson.core:jackson-databind` version to 2.10.1 for the security reason (https://nvd.nist.gov/vuln/detail/CVE-2020-11111).

