### PR TITLE
fix data loss exception while topic no data input

### DIFF
--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
@@ -547,6 +547,11 @@ public class PulsarFetcher<T> {
     }
 
     protected ReaderThread createReaderThread(ExceptionProxy exceptionProxy, PulsarTopicState state) {
+        boolean failOnDataLoss = true;
+        if (readerConf.containsKey(PulsarOptions.FAIL_ON_DATA_LOSS_OPTION_KEY)) {
+            String failOnDataLossVal = readerConf.getOrDefault(PulsarOptions.FAIL_ON_DATA_LOSS_OPTION_KEY, "true").toString();
+            failOnDataLoss = Boolean.parseBoolean(failOnDataLossVal);
+        }
         return new ReaderThread(
                 this,
                 state,
@@ -554,7 +559,7 @@ public class PulsarFetcher<T> {
                 readerConf,
                 deserializer,
                 pollTimeoutMs,
-                exceptionProxy);
+                exceptionProxy, failOnDataLoss);
     }
 
     /**
@@ -686,5 +691,9 @@ public class PulsarFetcher<T> {
 
         private BreakingException() {
         }
+    }
+
+    public PulsarMetadataReader getMetadataReader() {
+        return this.metadataReader;
     }
 }

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarMetadataReader.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarMetadataReader.java
@@ -416,6 +416,22 @@ public class PulsarMetadataReader implements AutoCloseable {
         return fullName.toString();
     }
 
+    public MessageId getLastMessageId(String topic) {
+        try {
+            return this.admin.topics().getLastMessageId(topic);
+        } catch (PulsarAdminException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void resetCursor(String topic, MessageId messageId) {
+        try {
+            this.admin.topics().resetCursor(topic, subscriptionName, messageId);
+        } catch (PulsarAdminException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     /**
      * Designate the close of the metadata reader.
      */

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/ReaderThread.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/ReaderThread.java
@@ -159,7 +159,6 @@ public class ReaderThread<T> extends Thread {
                 failOnDataLoss = false;
             }
             while (currentMessage == null && running) {
-                log.info("read current msg..");
                 currentMessage = reader.readNext(pollTimeoutMs, TimeUnit.MILLISECONDS);
                 if (failOnDataLoss) {
                     break;


### PR DESCRIPTION
**Describe the bug**

while read data from a pulsar topic which no data input any more or consume the expired topic offset, then the connector will throw the Exception that to report data Loss, as below

```
 java.lang.Exception: java.lang.IllegalStateException: Cannot read data at offset 436794:9261:3 from topic: persistent://test/test/test20-partition-3Some data may have been lost because they are not available in Pulsar any more; either the
 data was aged out by Pulsar or the topic may have been deleted before all the data in the
 topic was processed. If you don't want your streaming query to fail on such cases, set the
 source option "failOnDataLoss" to "false".
	at org.apache.flink.streaming.runtime.tasks.SourceStreamTask$LegacySourceFunctionThread.checkThrowSourceExecutionException(SourceStreamTask.java:217)
	at org.apache.flink.streaming.runtime.tasks.SourceStreamTask.processInput(SourceStreamTask.java:133)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.run(StreamTask.java:301)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.invoke(StreamTask.java:406)
	at org.apache.flink.runtime.taskmanager.Task.doRun(Task.java:705)
	at org.apache.flink.runtime.taskmanager.Task.run(Task.java:530)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.IllegalStateException: Cannot read data at offset 436794:9261:3 from topic: persistent://test/test/test20-partition-3Some data may have been lost because they are not available in Pulsar any more; either the
 data was aged out by Pulsar or the topic may have been deleted before all the data in the
 topic was processed. If you don't want your streaming query to fail on such cases, set the
 source option "failOnDataLoss" to "false"
```

the exception will lead to flink job fail and restart, and the same error will happen in the restart job.

**To Reproduce**
Steps to reproduce the behavior:

1. consume a pulsar topic by flink job use pulsar connector;
2. Stop to input data to topic, and continue the consuming let job  consume to the latest msg;
3. restart the flink job to consume the topic with no data input;
4. then the exception will throw

**Expected behavior**
1. if no data input, the connector should wait util data come in, but not to throw exception, which will cause the job fail.
2. if consume from a expired offset, which may means data loss, the user should have a option to allow data loss or not, the current option is not task effect. 
