### PR TITLE
set subscription role to subscriptionName if user not set

### DIFF
--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSource.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSource.java
@@ -484,6 +484,8 @@ public class FlinkPulsarSource<T>
             ClassLoader userCodeClassLoader,
             StreamingRuntimeContext streamingRuntime) throws Exception {
 
+        readerConf.putIfAbsent(PulsarOptions.SUBSCRIPTION_ROLE_OPTION_KEY, getSubscriptionName());
+
         return new PulsarFetcher(
                 sourceContext,
                 seedTopicsWithInitialOffsets,

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarOptions.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarOptions.java
@@ -52,6 +52,7 @@ public class PulsarOptions {
     public static final String FAIL_ON_WRITE_OPTION_KEY = "failonwrite";
     public static final String POLL_TIMEOUT_MS_OPTION_KEY = "polltimeoutms";
     public static final String COMMIT_MAX_RETRIES = "commitmaxretries";
+    public static final String SUBSCRIPTION_ROLE_OPTION_KEY = "subscriptionRolePrefix";
     public static final String FAIL_ON_DATA_LOSS_OPTION_KEY = "failondataloss";
 
     public static final String INSTRUCTION_FOR_FAIL_ON_DATA_LOSS_FALSE =


### PR DESCRIPTION
**Description**

user will set both subscription name and subscription role preifx in pulsar source properties when create a pulsar source, compre to flink kafka connector only set a group id.

**Excepted behavior**

User can only set subscription name like Kafka Connector's group id, the subscription role prefix is default is same as subscription name .