### PR TITLE
Update pulsar-client-all version to 2.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 
     <!-- dependencies -->
     <!-- use Pulsar stable version -->
-    <pulsar.version>2.4.2</pulsar.version>
+    <pulsar.version>2.5.1</pulsar.version>
     <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <scalatest.version>3.0.3</scalatest.version>


### PR DESCRIPTION
# Motivation

Update the netty version to `4.1.48.Final` for the security reason, the netty is introduced by the pulsar client, so update the pulsar-client-all version to 2.5.1.