### PR TITLE
add feature: round robin topic partition assignment

### DIFF
--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/SourceSinkUtils.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/SourceSinkUtils.java
@@ -70,6 +70,15 @@ public class SourceSinkUtils {
     }
 
     public static boolean belongsTo(String topic, int numParallelSubtasks, int index) {
+        if (topic.contains(PulsarOptions.PARTITION_SUFFIX)) {
+            int pos = topic.lastIndexOf(PulsarOptions.PARTITION_SUFFIX);
+            String topicPrefix = topic.substring(0, pos);
+            String topicPartitionIndex = topic.substring(pos + PulsarOptions.PARTITION_SUFFIX.length());
+            if (topicPartitionIndex.matches("-?(0|[1-9]\\d*)")) {
+                return ((topicPrefix.hashCode() * 31 & Integer.MAX_VALUE) + Integer.valueOf(topicPartitionIndex))
+                        % numParallelSubtasks == index;
+            }
+        }
         return (topic.hashCode() * 31 & Integer.MAX_VALUE) % numParallelSubtasks == index;
     }
 

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/SourceSinkUtils.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/SourceSinkUtils.java
@@ -74,8 +74,9 @@ public class SourceSinkUtils {
             int pos = topic.lastIndexOf(PulsarOptions.PARTITION_SUFFIX);
             String topicPrefix = topic.substring(0, pos);
             String topicPartitionIndex = topic.substring(pos + PulsarOptions.PARTITION_SUFFIX.length());
-            if (topicPartitionIndex.matches("-?(0|[1-9]\\d*)")) {
-                return ((topicPrefix.hashCode() * 31 & Integer.MAX_VALUE) + Integer.valueOf(topicPartitionIndex))
+            if (topicPartitionIndex.matches("0|[1-9]\\d*")) {
+                int startIndex = (topicPrefix.hashCode() * 31 & Integer.MAX_VALUE) % numParallelSubtasks;
+                return (startIndex + Integer.valueOf(topicPartitionIndex))
                         % numParallelSubtasks == index;
             }
         }

--- a/src/test/java/org/apache/flink/streaming/connectors/pulsar/testutils/TestMetadataReader.java
+++ b/src/test/java/org/apache/flink/streaming/connectors/pulsar/testutils/TestMetadataReader.java
@@ -15,8 +15,8 @@
 package org.apache.flink.streaming.connectors.pulsar.testutils;
 
 import org.apache.flink.streaming.connectors.pulsar.internal.PulsarMetadataReader;
-
 import org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions;
+
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.mockito.stubbing.Answer;


### PR DESCRIPTION
### Motivation

This pull request implements a round-robin topic assignment for partitioned-topic when assigning topics to different subtasks in flink programs. Our goal is to make the distribution of topics more even.

e.g. There is a flink job with parallelism=4, currently we may encounter:
```
topicA-partition-0 -> subtask-2
topicA-partition-1 -> subtask-3
topicA-partition-2 -> subtask-3
topicA-partition-3 -> subtask-2
```

And our goal is:
```
topicA-partition-0 -> subtask-2
topicA-partition-1 -> subtask-3
topicA-partition-2 -> subtask-0
topicA-partition-3 -> subtask-1
```

### Expected behaviors

1. For non-partitioned topics: 
Same as before

2. For partitioned topics: 
Assign partitions to subtasks as evenly as possible

### Modifications

Only modified the static method `belongsTo(String topic, int numParallelSubtasks, int index)` in `SourceSinkUtils`.