### PR TITLE
Failure commit should not cause task to fail

### DIFF
--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
@@ -459,7 +459,6 @@ public class PulsarFetcher<T> {
         } catch (Exception e) {
             if (running) {
                 offsetCommitCallback.onException(e);
-                throw e;
             } else {
                 return;
             }


### PR DESCRIPTION
### Motivation

Failure to commit offset should not continue to throw an exception upwards, causing the task to restart. At present, there will be 3 retry attempts after the commit fails, and the metric of commit-failed counter will be recorded when the number of retry attempts exceeds 3 times. I wonder if we should remove this line of throwing exception. Otherwise, it may be thrown out of the `notifyCheckpointComplete()` function, causing the flink task to fail and restart.

### Expected behaviors

The failure of commiting offsets should not affect the running source task.

### Modifications

Remove one line from `PulsarFetcher`.