### PR TITLE
add feature: enable earliest with external subscription mode

### DIFF
--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSource.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSource.java
@@ -132,6 +132,10 @@ public class FlinkPulsarSource<T>
      */
     private String externalSubscriptionName;
 
+    /** The subscription position to use when subscription does not exist (default is {@link MessageId#latest});
+     * Only relevant when startup mode is {@link StartupMode#EXTERNAL_SUBSCRIPTION}. */
+    private MessageId subscriptionPosition = MessageId.latest;
+
     // TODO: remove this when MessageId is serializable itself.
     // see: https://github.com/apache/pulsar/pull/6064
     private Map<String, byte[]> specificStartupOffsetsAsBytes;
@@ -333,6 +337,12 @@ public class FlinkPulsarSource<T>
         return this;
     }
 
+    public FlinkPulsarSource<T> setStartFromSubscription(String externalSubscriptionName, MessageId subscriptionPosition) {
+        this.startupMode = StartupMode.EXTERNAL_SUBSCRIPTION;
+        this.subscriptionPosition = subscriptionPosition;
+        this.externalSubscriptionName = checkNotNull(externalSubscriptionName);
+        return this;
+    }
 
     // ------------------------------------------------------------------------
     //  Work methods
@@ -743,7 +753,7 @@ public class FlinkPulsarSource<T>
             case EXTERNAL_SUBSCRIPTION:
                 Map<String, MessageId> offsetsFromSubs = new HashMap<>();
                 for (String topic : topics) {
-                    offsetsFromSubs.put(topic, metadataReader.getPositionFromSubscription(topic, MessageId.latest));
+                    offsetsFromSubs.put(topic, metadataReader.getPositionFromSubscription(topic, subscriptionPosition));
                 }
                 return offsetsFromSubs;
         }


### PR DESCRIPTION
### Motivation
This pull request implements an entrance to set default position in external subscription mode. Currently the default subscription position is hardcode to `MessageId.latest` when subscription name does not exist.

### Expected behaviors
- parameter `subscriptionPosition` is not set:
same as before

- parameter `subscriptionPosition` is set:
default subscription position can be identified as `MessageId.latest`(default) or `MessageId.earliest`

### Modifications
Only class `FlinkPulsarSource` was modified