### PR TITLE
bugfix_when_pulsarFetcher_cancel_readerthread

### DIFF
--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
@@ -300,7 +300,7 @@ public class PulsarFetcher<T> {
                 do { // check whether threads are alive and cancel them
                     runningThreads = 0;
 
-                    topicToThread.values().removeIf(ReaderThread::isAlive);
+                    topicToThread.values().removeIf(t -> !t.isAlive());
 
                     for (ReaderThread t : topicToThread.values()) {
                         t.cancel();

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
@@ -300,6 +300,7 @@ public class PulsarFetcher<T> {
                 do { // check whether threads are alive and cancel them
                     runningThreads = 0;
 
+                    // remove thread which is not alive
                     topicToThread.values().removeIf(t -> !t.isAlive());
 
                     for (ReaderThread t : topicToThread.values()) {


### PR DESCRIPTION
### Motivation
When an exception describe as "Exclusive consumer is already connected" is triggered  in flink puslar connector, `PulsarFetcher` will stuck in a loop in cancelling reader threads, can't throw exception to `FlinkPusarSource`, and the flink application is not work well but won't fail.

### Expected behaviors
When an excepiton triggered, `PulsarFetcher` should cancel reader thread and throw exception， but not stuck in a loop.

### Modifications
Only class `PulsarFetcher` was modified, change the  thread collections which should be cancelled