### PR TITLE
Revert "add feature: round robin topic partition assignment (#73)"

### DIFF
--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/SourceSinkUtils.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/SourceSinkUtils.java
@@ -70,16 +70,6 @@ public class SourceSinkUtils {
     }
 
     public static boolean belongsTo(String topic, int numParallelSubtasks, int index) {
-        if (topic.contains(PulsarOptions.PARTITION_SUFFIX)) {
-            int pos = topic.lastIndexOf(PulsarOptions.PARTITION_SUFFIX);
-            String topicPrefix = topic.substring(0, pos);
-            String topicPartitionIndex = topic.substring(pos + PulsarOptions.PARTITION_SUFFIX.length());
-            if (topicPartitionIndex.matches("0|[1-9]\\d*")) {
-                int startIndex = (topicPrefix.hashCode() * 31 & Integer.MAX_VALUE) % numParallelSubtasks;
-                return (startIndex + Integer.valueOf(topicPartitionIndex))
-                        % numParallelSubtasks == index;
-            }
-        }
         return (topic.hashCode() * 31 & Integer.MAX_VALUE) % numParallelSubtasks == index;
     }
 

--- a/src/test/java/org/apache/flink/streaming/connectors/pulsar/testutils/TestMetadataReader.java
+++ b/src/test/java/org/apache/flink/streaming/connectors/pulsar/testutils/TestMetadataReader.java
@@ -15,7 +15,6 @@
 package org.apache.flink.streaming.connectors.pulsar.testutils;
 
 import org.apache.flink.streaming.connectors.pulsar.internal.PulsarMetadataReader;
-import org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions;
 
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
@@ -68,15 +67,6 @@ public class TestMetadataReader extends PulsarMetadataReader {
     }
 
     public static int getExpectedSubtaskIndex(String tp, int numTasks) {
-        if (tp.contains(PulsarOptions.PARTITION_SUFFIX)) {
-            int pos = tp.lastIndexOf(PulsarOptions.PARTITION_SUFFIX);
-            String topicPrefix = tp.substring(0, pos);
-            String topicPartitionIndex = tp.substring(pos + PulsarOptions.PARTITION_SUFFIX.length());
-            if (topicPartitionIndex.matches("0|[1-9]\\d*")) {
-                int startIndex = (topicPrefix.hashCode() * 31 & Integer.MAX_VALUE) % numTasks;
-                return (startIndex + Integer.valueOf(topicPartitionIndex)) % numTasks;
-            }
-        }
-        return (tp.hashCode() * 31 & Integer.MAX_VALUE) % numTasks;
+        return ((tp.hashCode() * 31) & 0x7FFFFFFF) % numTasks;
     }
 }


### PR DESCRIPTION
This reverts commit 436bd0a0dea80d72dfddb7277929869a68db7dc0.

#73 changes the topic partition assignment algorithm. It is a breaking change to existing Flink jobs. Revert this change first. We can add #73 back with a feature flag.