### PR TITLE
Support KeyExtractor overwrite default topic

### DIFF
--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarRowSink.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarRowSink.java
@@ -115,7 +115,7 @@ public class FlinkPulsarRowSink extends FlinkPulsarSinkBase<Row> {
                         String.format("attribute unsupported type %s, %s must be a string", value.f0.toString(), TOPIC_ATTRIBUTE_NAME));
             }
         } else {
-            if (!forcedTopic) {
+            if (defaultTopic == null) {
                 throw new IllegalStateException(
                         String.format("topic option required when no %s attribute is present.", TOPIC_ATTRIBUTE_NAME));
             }
@@ -204,11 +204,9 @@ public class FlinkPulsarRowSink extends FlinkPulsarSinkBase<Row> {
         Row valueRow = valueProjection.apply(value);
         Object v = serializer.serialize(valueRow);
 
-        String topic;
-        if (forcedTopic) {
+        String topic = (String) metaRow.getField(0);
+        if (null == topic) {
             topic = defaultTopic;
-        } else {
-            topic = (String) metaRow.getField(0);
         }
 
         String key = (String) metaRow.getField(1);

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSink.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSink.java
@@ -63,19 +63,11 @@ public class FlinkPulsarSink<T> extends FlinkPulsarSinkBase<T> {
 
         TypedMessageBuilder<T> mb;
 
-        if (forcedTopic) {
-            mb = (TypedMessageBuilder<T>) getProducer(defaultTopic).newMessage().value(value);
+        if (null == topicKeyExtractor) {
+            mb = (TypedMessageBuilder<T>) getProducer(null).newMessage().value(value);
         } else {
             byte[] key = topicKeyExtractor.serializeKey(value);
             String topic = topicKeyExtractor.getTopic(value);
-
-            if (topic == null) {
-                if (failOnWrite) {
-                    throw new NullPointerException("no topic present in the data.");
-                }
-                return;
-            }
-
             mb = (TypedMessageBuilder<T>) getProducer(topic).newMessage().value(value);
             if (key != null) {
                 mb.keyBytes(key);


### PR DESCRIPTION
*Motivation*

Currently the sink connector only supports two modes:

- default output topic is set: the key extractor will be ignored
- default output topic is not set: the key extractor is required to return a non-null topic

In some use cases, a key extractor can return null topic. We want those messages are sent to the default
topic. This change modifies the existing logic to support KeyExtractor overwriting default topic.