### PR TITLE
Fix serialization of timestamps

### DIFF
--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarSerializer.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarSerializer.java
@@ -210,7 +210,7 @@ public class PulsarSerializer {
             return (getter, ordinal) -> ByteBuffer.wrap((byte[]) getter.getField(ordinal));
         } else if (tpe == LogicalTypeRoot.DATE && atpe == Schema.Type.INT) {
             return (getter, ordinal) -> DateTimeUtils.fromJavaDate((java.sql.Date) getter.getField(ordinal));
-        } else if (tpe == LogicalTypeRoot.TIMESTAMP_WITH_TIME_ZONE && atpe == Schema.Type.LONG) {
+        } else if (tpe == LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE && atpe == Schema.Type.LONG) {
             LogicalType altpe = avroType.getLogicalType();
             if (altpe instanceof LogicalTypes.TimestampMillis) {
                 return (getter, ordinal) -> DateTimeUtils.fromJavaTimestamp((java.sql.Timestamp) getter.getField(ordinal)) / 1000;


### PR DESCRIPTION
I believe this is a typo, as this is the only place `TIMESTAMP_WITH_TIME_ZONE` appears in the code. In any case, it stops serialization of the flink type `TIMESTAMP(3)` and Java timestamps don't have a timezone anyway.