### PR TITLE
fix failOnDataLoss

### DIFF
--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
@@ -551,6 +551,7 @@ public class PulsarFetcher<T> {
         if (readerConf.containsKey(PulsarOptions.FAIL_ON_DATA_LOSS_OPTION_KEY)) {
             String failOnDataLossVal = readerConf.getOrDefault(PulsarOptions.FAIL_ON_DATA_LOSS_OPTION_KEY, "true").toString();
             failOnDataLoss = Boolean.parseBoolean(failOnDataLossVal);
+            log.info("Create reader with failOnDataLoss {}", failOnDataLoss);
         }
         return new ReaderThread(
                 this,

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/ReaderThread.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/ReaderThread.java
@@ -152,7 +152,7 @@ public class ReaderThread<T> extends Thread {
                     log.error("the start message id is beyond the last commit message id, with topic:{}", reader.getTopic());
                     throw new RuntimeException("start message id beyond the last commit");
                 } else if (!failOnDataLoss) {
-                    log.info("reset message to valid offset");
+                    log.info("reset message to valid offset {}", startMessageId);
                     this.owner.getMetadataReader().resetCursor(reader.getTopic(), startMessageId);
                 }
             } else {
@@ -170,7 +170,7 @@ public class ReaderThread<T> extends Thread {
                         topic));
             } else {
                 currentId = currentMessage.getMessageId();
-                if (!messageIdRoughEquals(currentId, startMessageId)) {
+                if (!messageIdRoughEquals(currentId, startMessageId) && failOnDataLoss) {
                     reportDataLoss(
                             String.format(
                                     "Potential Data Loss in reading %s: intended to start at %s, actually we get %s",

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/ReaderThread.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/ReaderThread.java
@@ -90,7 +90,7 @@ public class ReaderThread<T> extends Thread {
 
     @Override
     public void run() {
-        log.info("Starting to fetch from {} at {}", topic, startMessageId);
+        log.info("Starting to fetch from {} at {}, failOnDataLoss {}", topic, startMessageId, failOnDataLoss);
 
         try {
             createActualReader();


### PR DESCRIPTION
Fix #100 
in PR #70, failOnDataLoss is supported.
If failOnDataLoss is set to false, it should not fail if the messaged readout is not as the one that passed-in.