### PR TITLE
Fix subscription miss create on failOnDataLoss=false and useExternalSub

### DIFF
--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
@@ -102,6 +102,8 @@ public class PulsarFetcher<T> {
 
     protected final Map<String, Object> readerConf;
 
+    protected final boolean failOnDataLoss;
+
     protected final DeserializationSchema<T> deserializer;
 
     protected final int pollTimeoutMs;
@@ -229,6 +231,14 @@ public class PulsarFetcher<T> {
                     autoWatermarkInterval);
 
             periodicEmitter.start();
+        }
+
+        // get failOnDataLoss from reader conf
+        if (readerConf.containsKey(PulsarOptions.FAIL_ON_DATA_LOSS_OPTION_KEY)) {
+            String failOnDataLossVal = readerConf.getOrDefault(PulsarOptions.FAIL_ON_DATA_LOSS_OPTION_KEY, "true").toString();
+            failOnDataLoss = Boolean.parseBoolean(failOnDataLossVal);
+        } else {
+            failOnDataLoss = true;
         }
     }
 
@@ -528,7 +538,7 @@ public class PulsarFetcher<T> {
             ExceptionProxy exceptionProxy) {
 
         Map<String, MessageId> startingOffsets = states.stream().collect(Collectors.toMap(PulsarTopicState::getTopic, PulsarTopicState::getOffset));
-        metadataReader.setupCursor(startingOffsets);
+        metadataReader.setupCursor(startingOffsets, failOnDataLoss);
         Map<String, ReaderThread> topic2Threads = new HashMap<>();
 
         for (PulsarTopicState state : states) {
@@ -547,12 +557,8 @@ public class PulsarFetcher<T> {
     }
 
     protected ReaderThread createReaderThread(ExceptionProxy exceptionProxy, PulsarTopicState state) {
-        boolean failOnDataLoss = true;
-        if (readerConf.containsKey(PulsarOptions.FAIL_ON_DATA_LOSS_OPTION_KEY)) {
-            String failOnDataLossVal = readerConf.getOrDefault(PulsarOptions.FAIL_ON_DATA_LOSS_OPTION_KEY, "true").toString();
-            failOnDataLoss = Boolean.parseBoolean(failOnDataLossVal);
-            log.info("Create reader with failOnDataLoss {}", failOnDataLoss);
-        }
+        log.info("Create reader with failOnDataLoss {}", failOnDataLoss);
+
         return new ReaderThread(
                 this,
                 state,

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
@@ -234,7 +234,7 @@ public class PulsarFetcher<T> {
         }
 
         // get failOnDataLoss from reader conf
-        if (readerConf.containsKey(PulsarOptions.FAIL_ON_DATA_LOSS_OPTION_KEY)) {
+        if (readerConf != null && readerConf.containsKey(PulsarOptions.FAIL_ON_DATA_LOSS_OPTION_KEY)) {
             String failOnDataLossVal = readerConf.getOrDefault(PulsarOptions.FAIL_ON_DATA_LOSS_OPTION_KEY, "true").toString();
             failOnDataLoss = Boolean.parseBoolean(failOnDataLossVal);
         } else {

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarMetadataReader.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarMetadataReader.java
@@ -26,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.ListUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.admin.PulsarAdminException.ConflictException;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.MessageIdImpl;
@@ -223,15 +224,18 @@ public class PulsarMetadataReader implements AutoCloseable {
     }
 
     public void setupCursor(Map<String, MessageId> offset, boolean failOnDataLoss) {
+        // if failOnDataLoss is false, we could continue, and re-create the sub.
         if (!useExternalSubscription || !failOnDataLoss) {
             for (Map.Entry<String, MessageId> entry : offset.entrySet()) {
                 try {
                     log.info("Setting up subscription {} on topic {} at position {}", subscriptionName, entry.getKey(), entry.getValue());
                     admin.topics().createSubscription(entry.getKey(), subscriptionName, entry.getValue());
                     log.info("Subscription {} on topic {} at position {} finished", subscriptionName, entry.getKey(), entry.getValue());
+                } catch (ConflictException e) {
+                    log.info("Subscription {} on topic {} already exists", subscriptionName, entry.getKey());
                 } catch (PulsarAdminException e) {
                     throw new RuntimeException(
-                            String.format("Failed to set up cursor for %s", TopicName.get(entry.getKey()).toString()), e);
+                            String.format("Failed to set up cursor for %s ", TopicName.get(entry.getKey()).toString()), e);
                 }
             }
         }

--- a/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarMetadataReader.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarMetadataReader.java
@@ -222,8 +222,8 @@ public class PulsarMetadataReader implements AutoCloseable {
         SchemaUtils.uploadPulsarSchema(admin, topic, si);
     }
 
-    public void setupCursor(Map<String, MessageId> offset) {
-        if (!useExternalSubscription) {
+    public void setupCursor(Map<String, MessageId> offset, boolean failOnDataLoss) {
+        if (!useExternalSubscription || !failOnDataLoss) {
             for (Map.Entry<String, MessageId> entry : offset.entrySet()) {
                 try {
                     log.info("Setting up subscription {} on topic {} at position {}", subscriptionName, entry.getKey(), entry.getValue());
@@ -235,6 +235,10 @@ public class PulsarMetadataReader implements AutoCloseable {
                 }
             }
         }
+    }
+
+    public void setupCursor(Map<String, MessageId> offset) {
+        setupCursor(offset, true);
     }
 
     public void commitCursorToOffset(Map<String, MessageId> offset) {


### PR DESCRIPTION
Fix subscription miss create on failOnDataLoss=false and source.setStartFromSubscription. or user will meet error of "Subscription not found".

An error that user meet is like this:
```
Flink state is backed up from system 1.  Pulsar is installed on a system 2. The topic is created on the system 2. Flink state is restored in system2. The cursor position in the flink state does not correspond to the cursor position of the topic in the Pulsar in system 2. With failOnDataLoss set to false, the flink job meet error "Subscription not found"
```