### PR TITLE
Add retry to unit test 

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -37,9 +37,8 @@ jobs:
         uses: aahmed-se/setup-maven@v3
         with:
           maven-version: 3.6.1
-
       - name: run precommit script
-        run: ./precommit.sh scala-2.11
+        run: ./build/retry.sh `pwd`/precommit.sh scala-2.11
 
   unit-tests-scala-2_12:
     runs-on: ubuntu-latest
@@ -60,4 +59,4 @@ jobs:
           maven-version: 3.6.1
 
       - name: run precommit script
-        run: ./precommit.sh scala-2.12
+        run: ./build/retry.sh `pwd`/precommit.sh scala-2.12

--- a/build/retry.sh
+++ b/build/retry.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+function fail {
+  echo $1 >&2
+  exit 1
+}
+
+function retry {
+  local n=1
+  local max=3
+  local delay=10
+  while true; do
+    "$@" && break || {
+      if [[ $n -lt $max ]]; then
+        ((n++))
+        echo "Command failed. Attempt $n/$max:"
+        sleep $delay;
+      else
+        fail "The command has failed after $n attempts."
+      fi
+    }
+  done
+}
+
+retry $@

--- a/precommit.sh
+++ b/precommit.sh
@@ -22,7 +22,7 @@ PROFILE=${1}
 
 cd ${PRJ_HOME}
 
-mvn clean license:check install checkstyle:check spotbugs:check -P${PROFILE}
+mvn -B -ntp -q clean license:check install checkstyle:check spotbugs:check -P${PROFILE}
 cat target/surefire-reports/*.txt
 retcode=$?
 exit $retcode


### PR DESCRIPTION
## Motivation
When performing unit tests, downloading dependencies is prone to errors. Adding retries can solve most problems.

## Expected behaviors
add retry to unit test 