### PR TITLE
Fix concurrent modification

### DIFF
--- a/pulsar-flink-1.11/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarDeserializer.java
+++ b/pulsar-flink-1.11/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarDeserializer.java
@@ -103,11 +103,11 @@ public class PulsarDeserializer implements PulsarDeserializationSchema<Row>{
                     } else {
                         fieldsNum = st.getChildren().size();
                     }
-                    RowUpdater fieldUpdater = new RowUpdater();
                     Schema avroSchema =
                             new Schema.Parser().parse(new String(schemaInfo.getSchema(), StandardCharsets.UTF_8));
                     BinFunction<RowUpdater, GenericRecord> writer = getRecordWriter(avroSchema, st, new ArrayList<>());
                     this.converter = msg -> {
+                        RowUpdater fieldUpdater = new RowUpdater();
                         Row resultRow = new Row(fieldsNum);
                         fieldUpdater.setRow(resultRow);
                         Object value = msg.getValue();
@@ -147,9 +147,9 @@ public class PulsarDeserializer implements PulsarDeserializationSchema<Row>{
                     break;
 
                 default:
-                    RowUpdater fUpdater = new RowUpdater();
                     TriFunction<RowUpdater, Integer, Object> writer2 = newAtomicWriter(rootDataType);
                     this.converter = msg -> {
+                        RowUpdater fUpdater = new RowUpdater();
                         int rowSize = useExtendField ? 1 + META_FIELD_NAMES.size() : 1;
                         Row tmpRow = new Row(rowSize);
                         fUpdater.setRow(tmpRow);

--- a/pulsar-flink-1.11/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarTestBase.java
+++ b/pulsar-flink-1.11/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarTestBase.java
@@ -27,6 +27,7 @@ import io.streamnative.tests.pulsar.service.PulsarServiceFactory;
 import io.streamnative.tests.pulsar.service.PulsarServiceSpec;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.NotImplementedException;
+import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
@@ -34,6 +35,7 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.shade.com.google.common.collect.Sets;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -70,7 +72,7 @@ public abstract class PulsarTestBase extends TestLogger {
         log.info("    Starting PulsarTestBase ");
         log.info("-------------------------------------------------------------------------");
 
-        System.setProperty("pulsar.systemtest.image", "streamnative/pulsar-all:2.6.0-sn-18-3");
+        System.setProperty("pulsar.systemtest.image", "streamnative/pulsar:2.6.0-sn-18-3");
         PulsarServiceSpec spec = PulsarServiceSpec.builder()
                 .clusterName("standalone-" + UUID.randomUUID())
                 .enableContainerLogging(false)
@@ -86,12 +88,12 @@ public abstract class PulsarTestBase extends TestLogger {
                 adminUrl = uri.toString();
             }
         }
-        Thread.sleep(80 * 1000L);
-
+        try (PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(adminUrl).build()) {
+            admin.namespaces().createNamespace("public/default", Sets.newHashSet("standalone"));
+        }
         log.info("-------------------------------------------------------------------------");
         log.info("Successfully started pulsar service at cluster " + spec.clusterName());
         log.info("-------------------------------------------------------------------------");
-
     }
 
     @AfterClass

--- a/pulsar-flink-1.9/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarTestBase.java
+++ b/pulsar-flink-1.9/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarTestBase.java
@@ -34,9 +34,9 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.shade.com.google.common.collect.Sets;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.testcontainers.shaded.com.google.common.collect.Sets;
 
 import java.net.URI;
 import java.util.ArrayList;


### PR DESCRIPTION
When `PulsarDeserializer` is called in parallel by multiple threads, there is a situation where `fieldUpdater` is shared, which will cause the expected results not to be obtained.