### PR TITLE
Fix cast problem for properies() method in pulsar ConnectorDescriptor

### DIFF
--- a/pulsar-flink-connector/src/main/java/org/apache/flink/table/descriptors/Atomic.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/table/descriptors/Atomic.java
@@ -47,7 +47,6 @@ public class Atomic extends FormatDescriptor {
     protected Map<String, String> toFormatProperties() {
         final DescriptorProperties properties = new DescriptorProperties();
         properties.putString(AtomicValidator.FORMAT_CLASS_NAME, className);
-        //properties.putBoolean(ConnectorDescriptorValidator.CONNECTOR + "." + PulsarOptions.USE_EXTEND_FIELD, useExtendFields);
         return properties.asMap();
     }
 }

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/table/descriptors/Pulsar.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/table/descriptors/Pulsar.java
@@ -102,7 +102,7 @@ public class Pulsar extends ConnectorDescriptor {
             this.pulsarProperties = new HashMap<>();
         }
         this.pulsarProperties.clear();
-        properties.forEach((k, v) -> this.pulsarProperties.put((String) k, (String) v));
+        properties.forEach((k, v) -> this.pulsarProperties.put(String.valueOf(k), String.valueOf(v)));
         return this;
     }
 


### PR DESCRIPTION
This pull resquest fixes Pulsar connector. There is a cast problem when use properties method.

Properties extends Hashtable<Object,Object> ，The key and value of the Properties class support object. If the user's value is a boolean type, this code "(String) k, (String) v" will occur an error. such as : java.lang.ClassCastException: java.lang.Boolean cannot be cast to java.lang.String.

Although it is possible to force the user to use string types, but we should adapt to this boundary case.
