### PR TITLE
[FEATURE] support subscription for no schema topic

### DIFF
--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSource.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSource.java
@@ -16,6 +16,7 @@ package org.apache.flink.streaming.connectors.pulsar;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.RuntimeContextInitializationContextAdapters;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
@@ -48,6 +49,7 @@ import org.apache.flink.streaming.runtime.operators.util.AssignerWithPeriodicWat
 import org.apache.flink.streaming.runtime.operators.util.AssignerWithPunctuatedWatermarksAdapter;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.util.serialization.PulsarDeserializationSchema;
+import org.apache.flink.streaming.util.serialization.PulsarDeserializationSchemaWrapper;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.SerializedValue;
 
@@ -242,6 +244,15 @@ public class FlinkPulsarSource<T>
             PulsarDeserializationSchema<T> deserializer,
             Properties properties) {
         this(adminUrl, PulsarClientUtils.newClientConf(checkNotNull(serviceUrl), properties), deserializer, properties);
+    }
+
+    public FlinkPulsarSource(
+            String serviceUrl,
+            String adminUrl,
+            DeserializationSchema<T> deserializer,
+            Properties properties) {
+        this(adminUrl, PulsarClientUtils.newClientConf(checkNotNull(serviceUrl), properties),
+                new PulsarDeserializationSchemaWrapper<>(deserializer), properties);
     }
 
     // ------------------------------------------------------------------------

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/util/serialization/PulsarDeserializationSchemaWrapper.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/util/serialization/PulsarDeserializationSchemaWrapper.java
@@ -48,6 +48,11 @@ public class PulsarDeserializationSchemaWrapper<T> implements PulsarDeserializat
         this.dataType = checkNotNull(dataType);
     }
 
+    public PulsarDeserializationSchemaWrapper(DeserializationSchema<T> deSerializationSchema) {
+        this.deSerializationSchema = checkNotNull(deSerializationSchema);
+        this.dataType = null;
+    }
+
     @Override
     public Optional<String> getTargetTopic(T element) {
         return Optional.empty();
@@ -56,6 +61,11 @@ public class PulsarDeserializationSchemaWrapper<T> implements PulsarDeserializat
     @Override
     public Schema<T> getSchema() {
         SchemaInfo si = BytesSchema.of().getSchemaInfo();
+
+        if (dataType == null) {
+            // No need to consider the impact of DataType
+            return new FlinkSchema<>(si, null, deSerializationSchema);
+        }
 
         if (deSerializationSchema instanceof SimpleStringSchema) {
             si = (new SchemaInfo()).setName("String").setType(SchemaType.STRING).setSchema(new byte[0]);

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/util/serialization/PulsarDeserializationSchemaWrapper.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/util/serialization/PulsarDeserializationSchemaWrapper.java
@@ -15,21 +15,15 @@
 package org.apache.flink.streaming.util.serialization;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
-import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.formats.avro.AvroDeserializationSchema;
-import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
-import org.apache.flink.formats.json.JsonNodeDeserializationSchema;
 import org.apache.flink.table.types.DataType;
 
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.schema.BytesSchema;
 import org.apache.pulsar.common.schema.SchemaInfo;
-import org.apache.pulsar.common.schema.SchemaType;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -41,16 +35,13 @@ public class PulsarDeserializationSchemaWrapper<T> implements PulsarDeserializat
 
     private final DeserializationSchema<T> deSerializationSchema;
 
-    private final DataType dataType;
-
+    @Deprecated
     public PulsarDeserializationSchemaWrapper(DeserializationSchema<T> deSerializationSchema, DataType dataType) {
         this.deSerializationSchema = checkNotNull(deSerializationSchema);
-        this.dataType = checkNotNull(dataType);
     }
 
     public PulsarDeserializationSchemaWrapper(DeserializationSchema<T> deSerializationSchema) {
         this.deSerializationSchema = checkNotNull(deSerializationSchema);
-        this.dataType = null;
     }
 
     @Override
@@ -61,27 +52,6 @@ public class PulsarDeserializationSchemaWrapper<T> implements PulsarDeserializat
     @Override
     public Schema<T> getSchema() {
         SchemaInfo si = BytesSchema.of().getSchemaInfo();
-
-        if (dataType == null) {
-            // No need to consider the impact of DataType
-            return new FlinkSchema<>(si, null, deSerializationSchema);
-        }
-
-        if (deSerializationSchema instanceof SimpleStringSchema) {
-            si = (new SchemaInfo()).setName("String").setType(SchemaType.STRING).setSchema(new byte[0]);
-        } else if (deSerializationSchema instanceof AvroDeserializationSchema) {
-            final org.apache.avro.Schema schema = AvroSchemaConverter.convertToSchema(dataType.getLogicalType());
-            byte[] schemaBytes = schema.toString().getBytes(StandardCharsets.UTF_8);
-            si.setName("Record");
-            si.setSchema(schemaBytes);
-            si.setType(SchemaType.AVRO);
-        } else if (deSerializationSchema instanceof JsonNodeDeserializationSchema) {
-            final org.apache.avro.Schema schema = AvroSchemaConverter.convertToSchema(dataType.getLogicalType());
-            byte[] schemaBytes = schema.toString().getBytes(StandardCharsets.UTF_8);
-            si.setName("Record");
-            si.setSchema(schemaBytes);
-            si.setType(SchemaType.JSON);
-        }
         return new FlinkSchema<>(si, null, deSerializationSchema);
     }
 


### PR DESCRIPTION
## Motivation
This pull request implements an enhancement of the compatibility in consuming no-schema topic. Now I make attempt to migrate our flink program from version 1.9 to 1.12 and I found that it can't even consume messages with `SimpleStringSchema` as before. 
```java
// use as the example doc said
new FlinkPulsarSource<>(serviceUrl, adminUrl, new PulsarDeserializationSchemaWrapper<>(new SimpleStringSchema(), DataTypes.STRING()), props);
```

When I launch the flink program, I can receive such an error as soon. 
`java.util.concurrent.CompletionException: org.apache.pulsar.client.api.PulsarClientException$IncompatibleSchemaException: Topic does not have schema to check`

The key problem leading this scenario is the initialization of `ReadThread`. In the connector of flink-1.9 the initialization is `PulsarClientImpl#newReader()`, however in flink-1.12 it becomes `PulsarClientImpl#newReader(deserializer.getSchema())`. The differce between these two calls is that, one uses the default schema(`Schema.BYTES`), the other uses the user-specific schema. And in the `PulsarDeserializationSchemaWrapper`, the object of `SimpleStringSchema` would be forced to use the `SchemaType.STRING` as the schema. Notice that the default schema should be `Schema.BYTES` for no-schema topic. Therefore when we create a pulsar topic without schema and subscribe the topic as I mentioned above, the issue would be certainly reproduced.

## Expected Behaviors
Yes we can implement our own `PulsarDeserializationSchema` or inherit the `PulsarDeserializationSchemaWrapper` to solve the problem, but I think it would be better to be compatible with the previous version and let users easily understand the source api.
```java
// for example
new FlinkPulsarSource<>(serviceUrl, adminUrl, new SimpleStringSchema(), props);
```

## Modifications
add constructors in `PulsarDeserializationSchemaWrapper` and `FlinkPulsarSource` to support no-schema scenario