### PR TITLE
clear PulsarDeserializationSchema

### DIFF
--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSource.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSource.java
@@ -49,7 +49,6 @@ import org.apache.flink.streaming.runtime.operators.util.AssignerWithPeriodicWat
 import org.apache.flink.streaming.runtime.operators.util.AssignerWithPunctuatedWatermarksAdapter;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.util.serialization.PulsarDeserializationSchema;
-import org.apache.flink.streaming.util.serialization.PulsarDeserializationSchemaWrapper;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.SerializedValue;
 
@@ -252,7 +251,7 @@ public class FlinkPulsarSource<T>
             DeserializationSchema<T> deserializer,
             Properties properties) {
         this(adminUrl, PulsarClientUtils.newClientConf(checkNotNull(serviceUrl), properties),
-                new PulsarDeserializationSchemaWrapper<>(deserializer), properties);
+                PulsarDeserializationSchema.valueOnly(deserializer), properties);
     }
 
     // ------------------------------------------------------------------------

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/util/serialization/PulsarDeserializationSchema.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/util/serialization/PulsarDeserializationSchema.java
@@ -34,11 +34,10 @@ import java.io.Serializable;
 @PublicEvolving
 public interface PulsarDeserializationSchema<T> extends PulsarContextAware<T>, Serializable {
 
+    @Deprecated
     static <V> PulsarDeserializationSchemaBuilder<V> builder() {
         return new PulsarDeserializationSchemaBuilder<>();
     }
-
-    ;
 
     /**
      * Wraps a Flink {@link DeserializationSchema} to a {@link PulsarDeserializationSchema}.
@@ -57,11 +56,6 @@ public interface PulsarDeserializationSchema<T> extends PulsarContextAware<T>, S
             @Override
             public V deserialize(Message<V> message) throws IOException {
                 return valueDeserializer.deserialize(message.getData());
-            }
-
-            @Override
-            public void deserialize(Message<V> message, Collector<V> collector) throws IOException {
-                valueDeserializer.deserialize(message.getData(), collector);
             }
 
             @Override

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/util/serialization/PulsarDeserializationSchemaBuilder.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/util/serialization/PulsarDeserializationSchemaBuilder.java
@@ -25,8 +25,11 @@ import java.io.Serializable;
 
 /**
  * Pulsar deserialization schema builder.
+ *
  * @param <V>
+ * @deprecated {@link PulsarDeserializationSchema#valueOnly(DeserializationSchema)}
  */
+@Deprecated
 public class PulsarDeserializationSchemaBuilder<V> implements Serializable {
 
     private DeserializationSchema<V> valueDeserializer;
@@ -37,6 +40,7 @@ public class PulsarDeserializationSchemaBuilder<V> implements Serializable {
 
     private Schema<V> pulsarSchema;
 
+    @Deprecated
     public PulsarDeserializationSchemaBuilder() {
     }
 

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/util/serialization/PulsarDeserializationSchemaWrapper.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/util/serialization/PulsarDeserializationSchemaWrapper.java
@@ -30,7 +30,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * An interface for the deserialization of Pulsar messages.
+ *
+ * @deprecated {@link PulsarDeserializationSchema#valueOnly(DeserializationSchema)}
  */
+@Deprecated
 public class PulsarDeserializationSchemaWrapper<T> implements PulsarDeserializationSchema<T>, PulsarContextAware<T> {
 
     private final DeserializationSchema<T> deSerializationSchema;
@@ -40,6 +43,7 @@ public class PulsarDeserializationSchemaWrapper<T> implements PulsarDeserializat
         this.deSerializationSchema = checkNotNull(deSerializationSchema);
     }
 
+    @Deprecated
     public PulsarDeserializationSchemaWrapper(DeserializationSchema<T> deSerializationSchema) {
         this.deSerializationSchema = checkNotNull(deSerializationSchema);
     }


### PR DESCRIPTION
After adjusting the implementation of PulsarDeserializationSchema to only do the wrapping of DeserializationSchema, there are some redundant implementation classes in the project that need to be cleaned up