### PR TITLE
catalogTable support default properties

### DIFF
--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarCatalogSupport.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarCatalogSupport.java
@@ -30,6 +30,8 @@ import org.apache.pulsar.common.schema.SchemaInfo;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.streaming.connectors.pulsar.table.PulsarTableOptions.TOPIC;
+
 /**
  * catalog support.
  */
@@ -95,6 +97,20 @@ public class PulsarCatalogSupport {
         String topicName = objectPath2TopicName(tablePath);
         final TableSchema schema = table.getSchema();
         pulsarMetadataReader.putSchema(topicName, tableSchemaToPulsarSchema(format, schema));
+    }
+
+    /**
+     * Get default table properties by pulsar schemaRegistry.
+     * @param objectPath
+     * @return table properties
+     * @throws IncompatibleSchemaException
+     */
+    public Map<String, String> getCatalogTableDefaultProperties(ObjectPath objectPath) throws IncompatibleSchemaException {
+        String topicName = objectPath2TopicName(objectPath);
+        final SchemaInfo pulsarSchema = pulsarMetadataReader.getPulsarSchema(topicName);
+        Map<String, String> properties = schemaTranslator.schemaInfo2TableProperties(pulsarSchema);
+        properties.put(TOPIC.key(), topicName);
+        return properties;
     }
 
     private SchemaInfo tableSchemaToPulsarSchema(String format, TableSchema schema) throws IncompatibleSchemaException {

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/SchemaTranslator.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/SchemaTranslator.java
@@ -34,6 +34,7 @@ import org.apache.pulsar.client.impl.schema.ShortSchema;
 import org.apache.pulsar.common.schema.SchemaInfo;
 
 import java.io.Serializable;
+import java.util.Map;
 
 /**
  * schema translator.
@@ -48,6 +49,8 @@ public abstract class SchemaTranslator implements Serializable {
             throws IncompatibleSchemaException;
 
     public abstract DataType schemaInfo2SqlType(SchemaInfo si) throws IncompatibleSchemaException;
+
+    public abstract Map<String, String> schemaInfo2TableProperties(SchemaInfo si) throws IncompatibleSchemaException;
 
     public static Schema atomicType2PulsarSchema(DataType flinkType) throws IncompatibleSchemaException {
         LogicalTypeRoot type = flinkType.getLogicalType().getTypeRoot();

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/table/catalog/pulsar/PulsarCatalog.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/table/catalog/pulsar/PulsarCatalog.java
@@ -159,7 +159,11 @@ public class PulsarCatalog extends GenericInMemoryCatalog {
     @Override
     public CatalogBaseTable getTable(ObjectPath tablePath) throws TableNotExistException, CatalogException {
         try {
-            return new CatalogTableImpl(catalogSupport.getTableSchema(tablePath), properties, "");
+            //deep-copy properties
+            Map<String, String> catalogTableProperties  = new HashMap<>();
+            catalogTableProperties.putAll(properties);
+            catalogTableProperties.putAll(catalogSupport.getCatalogTableDefaultProperties(tablePath));
+            return new CatalogTableImpl(catalogSupport.getTableSchema(tablePath), catalogTableProperties, "");
         } catch (PulsarAdminException.NotFoundException e) {
             throw new TableNotExistException(getName(), tablePath, e);
         } catch (PulsarAdminException | IncompatibleSchemaException e) {

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/table/catalog/pulsar/PulsarCatalogValidator.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/table/catalog/pulsar/PulsarCatalogValidator.java
@@ -44,7 +44,7 @@ public class PulsarCatalogValidator extends CatalogDescriptorValidator {
         properties.validateString(CATALOG_SERVICE_URL, false, 1);
         properties.validateString(CATALOG_ADMIN_URL, false, 1);
         properties.validateInt(CATALOG_DEFAULT_PARTITIONS, true, 1);
-        properties.validateString(FormatDescriptorValidator.FORMAT, false);
+        properties.validateString(FormatDescriptorValidator.FORMAT, true);
         validateStartingOffsets(properties);
     }
 


### PR DESCRIPTION
### Motivation

1. make catalog format optional.
2. `PulsarCatalog.getTable()` support table default properties by pulsar `SchemaRegistry`. 

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no )
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation (no)
