### PR TITLE
Support ProtobufNative Schema TableSource format

### DIFF
--- a/pulsar-flink-connector/src/main/java/org/apache/flink/formats/protobufnative/PulsarProtobufNativeFormatFactory.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/formats/protobufnative/PulsarProtobufNativeFormatFactory.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.protobufnative;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DeserializationFormatFactory;
+import org.apache.flink.table.factories.DynamicTableFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.apache.flink.formats.json.JsonOptions.validateDecodingFormatOptions;
+import static org.apache.flink.streaming.connectors.pulsar.table.PulsarTableOptions.ADMIN_URL;
+import static org.apache.flink.streaming.connectors.pulsar.table.PulsarTableOptions.SERVICE_URL;
+import static org.apache.flink.streaming.connectors.pulsar.table.PulsarTableOptions.TOPIC;
+
+/**
+ * Support {@link org.apache.pulsar.client.impl.schema.ProtobufNativeSchema} based pulsar schema SchemaRegistry.
+ */
+@Slf4j
+public class PulsarProtobufNativeFormatFactory implements DeserializationFormatFactory {
+
+    public static final String IDENTIFIER = "pulsar-protobuf-native";
+
+    @Override
+    public DecodingFormat<DeserializationSchema<RowData>> createDecodingFormat(DynamicTableFactory.Context context, ReadableConfig formatOptions) {
+        FactoryUtil.validateFactoryOptions(this, formatOptions);
+        validateDecodingFormatOptions(formatOptions);
+
+        ReadableConfig tableConf = Configuration.fromMap(context.getCatalogTable().getOptions());
+
+        //TODO support multi topic ?
+        String topic = context.getCatalogTable().getOptions().get(TOPIC.key());
+        String adminUrl = tableConf.get(ADMIN_URL);
+        String serviceUrl = tableConf.get(SERVICE_URL);
+
+        return new DecodingFormat<DeserializationSchema<RowData>>() {
+            @Override
+            public DeserializationSchema<RowData> createRuntimeDecoder(
+                    DynamicTableSource.Context context, DataType producedDataType) {
+                final RowType rowType = (RowType) producedDataType.getLogicalType();
+                final TypeInformation<RowData> rowDataTypeInfo =
+                        context.createTypeInformation(producedDataType);
+                return new PulsarProtobufNativeRowDataDeserializationSchema(topic, adminUrl, serviceUrl, rowType, rowDataTypeInfo);
+            }
+
+            @Override
+            public ChangelogMode getChangelogMode() {
+                return ChangelogMode.insertOnly();
+            }
+        };
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        return Collections.emptySet();
+    }
+}

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/formats/protobufnative/PulsarProtobufNativeRowDataDeserializationSchema.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/formats/protobufnative/PulsarProtobufNativeRowDataDeserializationSchema.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.protobufnative;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.connectors.pulsar.internal.PulsarClientUtils;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.apache.pulsar.client.impl.schema.generic.GenericProtobufNativeSchema;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.schema.SchemaInfo;
+
+import java.io.IOException;
+
+@Slf4j
+public class PulsarProtobufNativeRowDataDeserializationSchema implements DeserializationSchema<RowData>{
+
+    private String topic;
+    private String adminUrl;
+    private String serviceUrl;
+    private RowType rowType;
+    private TypeInformation<RowData> rowDataTypeInfo;
+
+    //TODO maybe add nested ProtobufRowDataDeserializationSchema structured by Descriptor?
+    private transient Descriptors.Descriptor descriptor;
+    /** Runtime instance that performs the actual work. */
+    private transient PulsarProtobufToRowDataConverters.ProtobufToRowDataConverter runtimeConverter;
+
+    //TOOD add class-based-schema support?
+    public PulsarProtobufNativeRowDataDeserializationSchema(String topic, String adminUrl, String serviceUrl, RowType rowType, TypeInformation<RowData> rowDataTypeInfo) {
+        this.topic = topic;
+        this.adminUrl = adminUrl;
+        this.serviceUrl = serviceUrl;
+        this.rowDataTypeInfo = rowDataTypeInfo;
+        this.rowType = rowType;
+    }
+
+    @Override
+    public void open(InitializationContext context) throws Exception {
+        PulsarAdmin pulsarAdmin;
+        try {
+            ClientConfigurationData clientConf = new ClientConfigurationData();
+            clientConf.setServiceUrl(serviceUrl);
+            pulsarAdmin = PulsarClientUtils.newAdminFromConf(adminUrl, clientConf);
+        } catch (PulsarClientException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+
+        try {
+            //TODO add cache ?
+            SchemaInfo schemaInfo = pulsarAdmin.schemas().getSchemaInfo(TopicName.get(topic).toString());
+            this.descriptor = ((GenericProtobufNativeSchema) GenericProtobufNativeSchema.of(schemaInfo)).getProtobufNativeSchema();
+        } catch (PulsarAdminException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+        this.runtimeConverter = PulsarProtobufToRowDataConverters.createRowConverter(rowType);
+    }
+
+    @Override
+    public RowData deserialize(byte[] message) throws IOException {
+        if (message == null) {
+            return null;
+        }
+        try {
+            DynamicMessage deserialize = DynamicMessage.parseFrom(descriptor, message);
+            return (RowData) runtimeConverter.convert(deserialize);
+        } catch (Exception e) {
+            throw new IOException("Failed to deserialize ProtobufNative record.", e);
+        }
+    }
+
+    @Override
+    public boolean isEndOfStream(RowData nextElement) {
+        return false;
+    }
+
+    @Override
+    public TypeInformation<RowData> getProducedType() {
+        return rowDataTypeInfo;
+    }
+}

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/formats/protobufnative/PulsarProtobufToRowDataConverters.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/formats/protobufnative/PulsarProtobufToRowDataConverters.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.protobufnative;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.EnumValue;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
+
+import java.io.Serializable;
+import java.lang.reflect.Array;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+public class PulsarProtobufToRowDataConverters {
+
+    /**
+     * Runtime converter that converts protobuf data structures into objects of Flink Table & SQL
+     * internal data structures.
+     */
+    @FunctionalInterface
+    public interface ProtobufToRowDataConverter extends Serializable {
+        Object convert(Object object);
+    }
+
+    // -------------------------------------------------------------------------------------
+    // Runtime Converters
+    // -------------------------------------------------------------------------------------
+
+    public static PulsarProtobufToRowDataConverters.ProtobufToRowDataConverter createRowConverter(RowType rowType) {
+        final PulsarProtobufToRowDataConverters.ProtobufToRowDataConverter[] fieldConverters =
+                rowType.getFields().stream()
+                        .map(RowType.RowField::getType)
+                        .map(PulsarProtobufToRowDataConverters::createNullableConverter)
+                        .toArray(PulsarProtobufToRowDataConverters.ProtobufToRowDataConverter[]::new);
+        final int arity = rowType.getFieldCount();
+        return protobufObject -> {
+            DynamicMessage record = (DynamicMessage) protobufObject;
+            GenericRowData row = new GenericRowData(arity);
+            for (int i = 0; i < arity; ++i) {
+                String fieldName = rowType.getFieldNames().get(i);
+                row.setField(i, fieldConverters[i].convert(record.getField(record.getDescriptorForType().findFieldByName(fieldName))));
+            }
+            return row;
+        };
+    }
+
+    /** Creates a runtime converter which is null safe. */
+    private static PulsarProtobufToRowDataConverters.ProtobufToRowDataConverter createNullableConverter(LogicalType type) {
+        final PulsarProtobufToRowDataConverters.ProtobufToRowDataConverter converter = createConverter(type);
+        return object -> {
+            if (object == null) {
+                return null;
+            }
+            return converter.convert(object);
+        };
+    }
+
+    private static PulsarProtobufToRowDataConverters.ProtobufToRowDataConverter createConverter(LogicalType type) {
+        switch (type.getTypeRoot()) {
+            case NULL:
+                return null;
+            case BOOLEAN: // boolean
+            case INTEGER: // int
+            case BIGINT: // long
+            case DOUBLE: // double
+                return object -> object;
+            case CHAR:
+            case VARCHAR:
+                return object -> {
+                    // enum
+                    if (object instanceof EnumValue) {
+                        return ((EnumValue) object).getName();
+                    } else {
+                        return StringData.fromString(object.toString());
+                    }
+                };
+            case BINARY:
+            case VARBINARY:
+                return PulsarProtobufToRowDataConverters::convertToBytes;
+            case ARRAY:
+                return createArrayConverter((ArrayType) type);
+            case ROW:
+                return createRowConverter((RowType) type);
+            case MAP:
+                return createMapConverter((MapType) type);
+            default:
+                return object -> {
+                    throw new UnsupportedOperationException("Unsupported protobuf field type " + object.getClass() +
+                            " convert to" +
+                            " flink type: " + type);
+                };
+        }
+    }
+
+    private static PulsarProtobufToRowDataConverters.ProtobufToRowDataConverter createArrayConverter(ArrayType arrayType) {
+        final PulsarProtobufToRowDataConverters.ProtobufToRowDataConverter elementConverter =
+                createNullableConverter(arrayType.getElementType());
+        final Class<?> elementClass =
+                LogicalTypeUtils.toInternalConversionClass(arrayType.getElementType());
+
+        return protobufObject -> {
+            final List<?> list = (List<?>) protobufObject;
+            final int length = list.size();
+            final Object[] array = (Object[]) Array.newInstance(elementClass, length);
+            for (int i = 0; i < length; ++i) {
+                array[i] = elementConverter.convert(list.get(i));
+            }
+            return new GenericArrayData(array);
+        };
+    }
+
+    private static PulsarProtobufToRowDataConverters.ProtobufToRowDataConverter createMapConverter(MapType type) {
+
+        final PulsarProtobufToRowDataConverters.ProtobufToRowDataConverter keyConverter =
+                createConverter(type.getKeyType());
+        final PulsarProtobufToRowDataConverters.ProtobufToRowDataConverter valueConverter =
+                createNullableConverter(type.getValueType());
+
+        return object -> {
+            final Map<?, ?> map = (Map<?, ?>) object;
+            Map<Object, Object> result = new HashMap<>();
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                Object key = keyConverter.convert(entry.getKey());
+                Object value = valueConverter.convert(entry.getValue());
+                result.put(key, value);
+            }
+            return new GenericMapData(result);
+        };
+    }
+
+    private static byte[] convertToBytes(Object object) {
+        if (object instanceof ByteString) {
+            return ((ByteString) object).toByteArray();
+        } else {
+            return (byte[]) object;
+        }
+    }
+}

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/formats/protobufnative/PulsarProtobufToRowDataConverters.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/formats/protobufnative/PulsarProtobufToRowDataConverters.java
@@ -14,9 +14,6 @@
 
 package org.apache.flink.formats.protobufnative;
 
-import com.google.protobuf.ByteString;
-import com.google.protobuf.DynamicMessage;
-import com.google.protobuf.EnumValue;
 import org.apache.flink.table.data.GenericArrayData;
 import org.apache.flink.table.data.GenericMapData;
 import org.apache.flink.table.data.GenericRowData;
@@ -27,12 +24,15 @@ import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
 
+import com.google.protobuf.ByteString;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.EnumValue;
+
 import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 
 public class PulsarProtobufToRowDataConverters {
 
@@ -85,6 +85,7 @@ public class PulsarProtobufToRowDataConverters {
             case BOOLEAN: // boolean
             case INTEGER: // int
             case BIGINT: // long
+            case FLOAT:  // float
             case DOUBLE: // double
                 return object -> object;
             case CHAR:

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarClientUtils.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarClientUtils.java
@@ -36,6 +36,10 @@ public class PulsarClientUtils {
             .build();
 	}
 
+    public static PulsarAdmin newAdminFromConf(String adminUrl, Properties properties) throws PulsarClientException {
+        return newAdminFromConf(adminUrl, newClientConf(adminUrl, properties));
+    }
+
 	private static Authentication getAuth(ClientConfigurationData conf) throws PulsarClientException {
 		if (!StringUtils.isBlank(conf.getAuthPluginClassName()) && !StringUtils.isBlank(conf.getAuthParams())) {
 			return AuthenticationFactory.create(conf.getAuthPluginClassName(), conf.getAuthParams());

--- a/pulsar-flink-connector/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/pulsar-flink-connector/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -16,3 +16,4 @@ org.apache.flink.streaming.connectors.pulsar.table.PulsarDynamicTableFactory
 org.apache.flink.streaming.connectors.pulsar.table.UpsertPulsarDynamicTableFactory
 org.apache.flink.table.catalog.pulsar.factories.PulsarCatalogFactory
 org.apache.flink.formats.atomic.AtomicRowDataFormatFactory
+org.apache.flink.formats.protobufnative.PulsarProtobufNativeFormatFactory

--- a/pulsar-flink-connector/src/test/java/org/apache/flink/formats/protobufnative/PulsarProtobufNativeRowDataDeserializationSchemaTest.java
+++ b/pulsar-flink-connector/src/test/java/org/apache/flink/formats/protobufnative/PulsarProtobufNativeRowDataDeserializationSchemaTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.protobufnative;
+
+import org.apache.flink.formats.protobuf.PbRowTypeInformation;
+import org.apache.flink.streaming.connectors.pulsar.SchemaData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class PulsarProtobufNativeRowDataDeserializationSchemaTest {
+
+    @Test
+    public void deserialize() throws Exception {
+        RowType rowType = PbRowTypeInformation.generateRowType(SchemaData.descriptor);
+        PulsarProtobufNativeRowDataDeserializationSchema deserializationSchema = new PulsarProtobufNativeRowDataDeserializationSchema(() -> SchemaData.descriptor, rowType);
+        deserializationSchema.open(null);
+
+        final RowData rowData = deserializationSchema.deserialize(SchemaData.protobufData);
+        RowData newRowData = rowData;
+        assertEquals(9, newRowData.getArity());
+        assertEquals(1, newRowData.getInt(0));
+        assertEquals(2L, newRowData.getLong(1));
+        assertFalse((boolean) newRowData.getBoolean(2));
+        assertEquals(Float.valueOf(0.1f), Float.valueOf(newRowData.getFloat(3)));
+        assertEquals(Double.valueOf(0.01d), Double.valueOf(newRowData.getDouble(4)));
+        assertEquals("haha", newRowData.getString(5).toString());
+        assertEquals(1, (newRowData.getBinary(6))[0]);
+        assertEquals("IMAGES", newRowData.getString(7).toString());
+        assertEquals(1, newRowData.getInt(8));
+    }
+}

--- a/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarTableITest.java
+++ b/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarTableITest.java
@@ -41,11 +41,16 @@ import org.apache.flink.types.Row;
 
 import com.google.protobuf.ByteString;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.schema.JSONSchema;
+import org.apache.pulsar.client.impl.schema.ProtobufNativeSchemaUtils;
+import org.apache.pulsar.client.impl.schema.SchemaInfoImpl;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
@@ -64,6 +69,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.streaming.connectors.pulsar.SchemaData.BOOLEAN_LIST;
@@ -75,6 +81,7 @@ import static org.apache.flink.streaming.connectors.pulsar.internal.PulsarOption
 import static org.apache.flink.table.utils.TableTestMatchers.deepEqualTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Table API related Integration tests.
@@ -87,6 +94,8 @@ public class FlinkPulsarTableITest extends PulsarTestBaseWithFlink {
     private static final String AVRO_FORMAT = "avro";
 
     private static final String PROTOBUF_FORMAT = "protobuf";
+
+    private static final String PULSAR_PROTOBUF_NATIVE_FORMAT = "pulsar-protobuf-native";
 
     @Before
     public void clearState() {
@@ -109,8 +118,8 @@ public class FlinkPulsarTableITest extends PulsarTestBaseWithFlink {
         List<String> columns = new ArrayList<>();
         for (TableColumn tableColumn : tSchema.getTableColumns()) {
             final String column = MessageFormat.format(" `{0}` {1}",
-                    tableColumn.getName(),
-                    tableColumn.getType().getLogicalType().asSerializableString());
+                tableColumn.getName(),
+                tableColumn.getType().getLogicalType().asSerializableString());
             columns.add(column);
         }
 
@@ -118,13 +127,13 @@ public class FlinkPulsarTableITest extends PulsarTestBaseWithFlink {
 
         Table t = tEnv.sqlQuery("select `value` from " + tableName);
         tEnv.toDataStream(t, Boolean.class)
-                .map(new FailingIdentityMapper<>(BOOLEAN_LIST.size()))
-                .addSink(new SingletonStreamSink.StringSink<>()).setParallelism(1);
+            .map(new FailingIdentityMapper<>(BOOLEAN_LIST.size()))
+            .addSink(new SingletonStreamSink.StringSink<>()).setParallelism(1);
 
         TestUtils.tryExecute(see, "basic functionality");
         SingletonStreamSink.compareWithList(
-                BOOLEAN_LIST.subList(0, BOOLEAN_LIST.size() - 1).stream().map(Objects::toString)
-                        .collect(Collectors.toList()));
+            BOOLEAN_LIST.subList(0, BOOLEAN_LIST.size() - 1).stream().map(Objects::toString)
+                .collect(Collectors.toList()));
     }
 
     @Test(timeout = 40 * 1000L)
@@ -136,15 +145,15 @@ public class FlinkPulsarTableITest extends PulsarTestBaseWithFlink {
         see.setParallelism(1);
         DataStreamSource ds = see.fromCollection(fooList);
         ds.addSink(
-                new FlinkPulsarSink(
-                        serviceUrl, adminUrl, Optional.of(tp), getSinkProperties(),
-                        new PulsarSerializationSchemaWrapper.Builder<>(
-                                (SerializationSchema<SchemaData.Foo>) element -> {
-                                    JSONSchema<SchemaData.Foo> jsonSchema = JSONSchema.of(SchemaData.Foo.class);
-                                    return jsonSchema.encode(element);
-                                })
-                                .usePojoMode(SchemaData.Foo.class, RecordSchemaType.JSON)
-                                .build()));
+            new FlinkPulsarSink(
+                serviceUrl, adminUrl, Optional.of(tp), getSinkProperties(),
+                new PulsarSerializationSchemaWrapper.Builder<>(
+                    (SerializationSchema<SchemaData.Foo>) element -> {
+                        JSONSchema<SchemaData.Foo> jsonSchema = JSONSchema.of(SchemaData.Foo.class);
+                        return jsonSchema.encode(element);
+                    })
+                    .usePojoMode(SchemaData.Foo.class, RecordSchemaType.JSON)
+                    .build()));
 
         see.execute("write first");
 
@@ -157,12 +166,12 @@ public class FlinkPulsarTableITest extends PulsarTestBaseWithFlink {
         tEnv.executeSql(createTableSql(tableName, tp, tSchema, "json")).print();
         Table t = tEnv.sqlQuery("select i, f, bar from " + tableName);
         tEnv.toDataStream(t, SchemaData.Foo.class)
-                .map(new FailingIdentityMapper<>(fooList.size()))
-                .addSink(new SingletonStreamSink.StringSink<>()).setParallelism(1);
+            .map(new FailingIdentityMapper<>(fooList.size()))
+            .addSink(new SingletonStreamSink.StringSink<>()).setParallelism(1);
 
         TestUtils.tryExecute(env, "count elements from topics");
         SingletonStreamSink.compareWithList(
-                fooList.subList(0, fooList.size() - 1).stream().map(Objects::toString).collect(Collectors.toList()));
+            fooList.subList(0, fooList.size() - 1).stream().map(Objects::toString).collect(Collectors.toList()));
     }
 
     @Test(timeout = 40 * 1000L)
@@ -180,12 +189,12 @@ public class FlinkPulsarTableITest extends PulsarTestBaseWithFlink {
 
         Table t = tEnv.sqlQuery("select i, f, bar from " + tableName);
         tEnv.toDataStream(t, SchemaData.Foo.class)
-                .map(new FailingIdentityMapper<>(fooList.size()))
-                .addSink(new SingletonStreamSink.StringSink<>()).setParallelism(1);
+            .map(new FailingIdentityMapper<>(fooList.size()))
+            .addSink(new SingletonStreamSink.StringSink<>()).setParallelism(1);
 
         TestUtils.tryExecute(see, "test struct in json");
         SingletonStreamSink.compareWithList(
-                fooList.subList(0, fooList.size() - 1).stream().map(Objects::toString).collect(Collectors.toList()));
+            fooList.subList(0, fooList.size() - 1).stream().map(Objects::toString).collect(Collectors.toList()));
     }
 
     @Test(timeout = 40 * 1000L)
@@ -203,19 +212,19 @@ public class FlinkPulsarTableITest extends PulsarTestBaseWithFlink {
 
         Table t = tEnv.sqlQuery("select l from " + tableName);
         tEnv.toDataStream(t, SchemaData.FL.class)
-                .map(new FailingIdentityMapper<>(flList.size()))
-                .addSink(new SingletonStreamSink.StringSink<>()).setParallelism(1);
+            .map(new FailingIdentityMapper<>(flList.size()))
+            .addSink(new SingletonStreamSink.StringSink<>()).setParallelism(1);
         TestUtils.tryExecute(see, "test struct in json");
         SingletonStreamSink.compareWithList(
-                flList.subList(0, flList.size() - 1).stream().map(Objects::toString).collect(Collectors.toList()));
+            flList.subList(0, flList.size() - 1).stream().map(Objects::toString).collect(Collectors.toList()));
     }
 
     private TableSchema getTableSchema(String topicName) throws PulsarClientException, PulsarAdminException,
-            IncompatibleSchemaException {
+        IncompatibleSchemaException {
         Map<String, String> caseInsensitiveParams = new HashMap<>();
         caseInsensitiveParams.put(TOPIC_SINGLE_OPTION_KEY, topicName);
         PulsarMetadataReader reader =
-                new PulsarMetadataReader(adminUrl, new ClientConfigurationData(), "", caseInsensitiveParams, -1, -1);
+            new PulsarMetadataReader(adminUrl, new ClientConfigurationData(), "", caseInsensitiveParams, -1, -1);
         SchemaInfo pulsarSchema = reader.getPulsarSchema(topicName);
         final SimpleSchemaTranslator schemaTranslator = new SimpleSchemaTranslator();
         return schemaTranslator.pulsarSchemaToTableSchema(pulsarSchema);
@@ -237,13 +246,13 @@ public class FlinkPulsarTableITest extends PulsarTestBaseWithFlink {
 
         Table t = tEnv.sqlQuery("select l from " + tableName);
         tEnv.toDataStream(t, SchemaData.FA.class)
-                .map(new FailingIdentityMapper<>(faList.size()))
-                .addSink(new SingletonStreamSink.StringSink<>()).setParallelism(1);
+            .map(new FailingIdentityMapper<>(faList.size()))
+            .addSink(new SingletonStreamSink.StringSink<>()).setParallelism(1);
 
         TestUtils.tryExecute(see, "test struct in avro");
 
         SingletonStreamSink.compareWithList(
-                faList.subList(0, faList.size() - 1).stream().map(Objects::toString).collect(Collectors.toList()));
+            faList.subList(0, faList.size() - 1).stream().map(Objects::toString).collect(Collectors.toList()));
     }
 
     @Test(timeout = 40 * 1000L)
@@ -262,13 +271,13 @@ public class FlinkPulsarTableITest extends PulsarTestBaseWithFlink {
 
         Table t = tEnv.sqlQuery("select m from " + tableName);
         tEnv.toDataStream(t, SchemaData.FM.class)
-                .map(new FailingIdentityMapper<>(faList.size()))
-                .addSink(new SingletonStreamSink.StringSink<>()).setParallelism(1);
+            .map(new FailingIdentityMapper<>(faList.size()))
+            .addSink(new SingletonStreamSink.StringSink<>()).setParallelism(1);
 
         TestUtils.tryExecute(see, "test struct in avro");
 
         SingletonStreamSink.compareWithList(
-                fmList.subList(0, fmList.size() - 1).stream().map(Objects::toString).collect(Collectors.toList()));
+            fmList.subList(0, fmList.size() - 1).stream().map(Objects::toString).collect(Collectors.toList()));
     }
 
     @Test
@@ -302,53 +311,53 @@ public class FlinkPulsarTableITest extends PulsarTestBaseWithFlink {
         String extendParamStr = "";
         if (map != null && !map.isEmpty()) {
             extendParamStr = map.entrySet().stream()
-                    .map(e -> String.format("'%s' = '%s'", e.getKey(), e.getValue()))
-                    .collect(Collectors.joining(",\n"));
+                .map(e -> String.format("'%s' = '%s'", e.getKey(), e.getValue()))
+                .collect(Collectors.joining(",\n"));
             extendParamStr += ",\n";
         }
         createTable = String.format(
-                "create table pulsar (\n" +
-                        "  a INT, \n" +
-                        "  b BIGINT, \n" +
-                        "  c BOOLEAN, \n" +
-                        "  d FLOAT, \n" +
-                        "  e DOUBLE, \n" +
-                        "  f VARCHAR(32), \n" +
-                        "  g BYTES, \n" +
-                        "  h VARCHAR(32), \n" +
-                        "  f_abc_7d INT, \n" +
-                        " `eventTime` TIMESTAMP(3) METADATA, \n" +
-                        "  compute as a + 1, \n" +
-                        "  watermark for eventTime as eventTime\n" +
-                        ") with (\n" +
-                        "  'connector' = 'pulsar',\n" +
-                        "  'topic' = '%s',\n" +
-                        "  'service-url' = '%s',\n" +
-                        "  'admin-url' = '%s',\n" +
-                        "  'scan.startup.mode' = 'earliest', \n" +
-                        "%s" +
-                        "  %s \n" +
-                        ")",
-                topic,
-                serviceUrl,
-                adminUrl,
-                extendParamStr,
-                String.format("'format' = '%s'", PROTOBUF_FORMAT));
+            "create table pulsar (\n" +
+                "  a INT, \n" +
+                "  b BIGINT, \n" +
+                "  c BOOLEAN, \n" +
+                "  d FLOAT, \n" +
+                "  e DOUBLE, \n" +
+                "  f VARCHAR(32), \n" +
+                "  g BYTES, \n" +
+                "  h VARCHAR(32), \n" +
+                "  f_abc_7d INT, \n" +
+                " `eventTime` TIMESTAMP(3) METADATA, \n" +
+                "  compute as a + 1, \n" +
+                "  watermark for eventTime as eventTime\n" +
+                ") with (\n" +
+                "  'connector' = 'pulsar',\n" +
+                "  'topic' = '%s',\n" +
+                "  'service-url' = '%s',\n" +
+                "  'admin-url' = '%s',\n" +
+                "  'scan.startup.mode' = 'earliest', \n" +
+                "%s" +
+                "  %s \n" +
+                ")",
+            topic,
+            serviceUrl,
+            adminUrl,
+            extendParamStr,
+            String.format("'format' = '%s'", PROTOBUF_FORMAT));
 
         SimpleTest.newBuilder()
-                .setA(1)
-                .setB(2L)
-                .setC(false)
-                .setD(0.1f)
-                .setE(0.01)
-                .setF("haha")
-                .setG(ByteString.copyFrom(new byte[]{1}))
-                .setH(SimpleTest.Corpus.IMAGES)
-                .setFAbc7D(1) // test fieldNameToJsonName
-                .build();
+            .setA(1)
+            .setB(2L)
+            .setC(false)
+            .setD(0.1f)
+            .setE(0.01)
+            .setF("haha")
+            .setG(ByteString.copyFrom(new byte[]{1}))
+            .setH(SimpleTest.Corpus.IMAGES)
+            .setFAbc7D(1) // test fieldNameToJsonName
+            .build();
         tEnv.executeSql(createTable).await();
         String initialValues = "INSERT INTO pulsar\n" +
-                "VALUES (1,2,false,0.1,0.01,'haha', ENCODE('1', 'utf-8'), 'IMAGES',1, TIMESTAMP '2020-03-08 13:12:11.123')";
+            "VALUES (1,2,false,0.1,0.01,'haha', ENCODE('1', 'utf-8'), 'IMAGES',1, TIMESTAMP '2020-03-08 13:12:11.123')";
         tEnv.executeSql(initialValues).await();
 
         // ---------- Consume stream from Pulsar -------------------
@@ -364,6 +373,85 @@ public class FlinkPulsarTableITest extends PulsarTestBaseWithFlink {
         assertEquals(expected, TestingSinkFunction.rows);
     }
 
+    @Test
+    public void testPulsarProtobufNativeSQLWork() throws Exception {
+        StreamExecutionEnvironment see = StreamExecutionEnvironment.getExecutionEnvironment();
+        see.setParallelism(1);
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(see);
+
+        String topic = newTopic();
+        try (PulsarAdmin admin = getPulsarAdmin()) {
+            admin.topics().createNonPartitionedTopic(topic);
+            admin.topics().createSubscription(topic, "test1", MessageId.earliest);
+        }
+        sendProtobufMessage(topic, 2);
+
+        final String createTable = String.format(
+            "create table pulsar (\n" +
+                "  a INT, \n" +
+                "  b BIGINT, \n" +
+                "  c BOOLEAN, \n" +
+                "  d FLOAT, \n" +
+                "  e DOUBLE, \n" +
+                "  f VARCHAR(32), \n" +
+                "  g BYTES, \n" +
+                "  h VARCHAR(32), \n" +
+                "  f_abc_7d INT, \n" +
+                " `eventTime` TIMESTAMP(3) METADATA, \n" +
+                "  compute as a + 1, \n" +
+                "  watermark for eventTime as eventTime\n" +
+                ") with (\n" +
+                "  'connector' = 'pulsar',\n" +
+                "  'topic' = '%s',\n" +
+                "  'service-url' = '%s',\n" +
+                "  'admin-url' = '%s',\n" +
+                "  'scan.startup.mode' = 'earliest', \n" +
+                "  %s \n" +
+                ")",
+            topic,
+            serviceUrl,
+            adminUrl,
+            String.format("'format' = '%s'", PULSAR_PROTOBUF_NATIVE_FORMAT));
+        tEnv.executeSql(createTable).await(10, TimeUnit.SECONDS);
+        String query = "SELECT * FROM pulsar \n";
+        List<RowData> result = tEnv.toAppendStream(tEnv.sqlQuery(query), RowData.class).executeAndCollect(1);
+
+        RowData newRowData = result.get(0);
+        assertEquals(1, newRowData.getInt(0));
+        assertEquals(2L, newRowData.getLong(1));
+        assertFalse((boolean) newRowData.getBoolean(2));
+        assertEquals(Float.valueOf(0.1f), Float.valueOf(newRowData.getFloat(3)));
+        assertEquals(Double.valueOf(0.01d), Double.valueOf(newRowData.getDouble(4)));
+        assertEquals("haha", newRowData.getString(5).toString());
+        assertEquals(1, (newRowData.getBinary(6))[0]);
+        assertEquals("IMAGES", newRowData.getString(7).toString());
+        assertEquals(1, newRowData.getInt(8));
+    }
+
+    private void sendProtobufMessage(String topic, int count) throws PulsarClientException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("__PARSING_INFO__", "[{\"number\":1,\"name\":\"a\",\"type\":\"INT32\",\"label\":\"LABEL_OPTIONAL\",\"definition\":null},{\"number\":2,\"name\":\"b\",\"type\":\"INT64\",\"label\":\"LABEL_OPTIONAL\",\"definition\":null},{\"number\":3,\"name\":\"c\",\"type\":\"BOOL\",\"label\":\"LABEL_OPTIONAL\",\"definition\":null},{\"number\":4,\"name\":\"d\",\"type\":\"FLOAT\",\"label\":\"LABEL_OPTIONAL\",\"definition\":null},{\"number\":5,\"name\":\"e\",\"type\":\"DOUBLE\",\"label\":\"LABEL_OPTIONAL\",\"definition\":null},{\"number\":6,\"name\":\"f\",\"type\":\"STRING\",\"label\":\"LABEL_OPTIONAL\",\"definition\":null},{\"number\":7,\"name\":\"g\",\"type\":\"BYTES\",\"label\":\"LABEL_OPTIONAL\",\"definition\":null},{\"number\":8,\"name\":\"h\",\"type\":\"ENUM\",\"label\":\"LABEL_OPTIONAL\",\"definition\":null},{\"number\":9,\"name\":\"f_abc_7d\",\"type\":\"INT32\",\"label\":\"LABEL_OPTIONAL\",\"definition\":null}]");
+        properties.put("__alwaysAllowNull", "true");
+        properties.put("__jsr310ConversionEnabled", "false");
+
+        final SchemaInfoImpl schemaInfo = SchemaInfoImpl.builder()
+            .schema(ProtobufNativeSchemaUtils.serialize(SchemaData.descriptor))
+            .name("simpleTest1")
+            .type(SchemaType.PROTOBUF_NATIVE)
+            .properties(properties)
+            .build();
+
+        final Schema<?> schema = Schema.getSchema(schemaInfo);
+        try (final Producer<byte[]> producer = getPulsarClient().newProducer(Schema.AUTO_PRODUCE_BYTES(schema))
+            .topic(topic)
+            .create()
+        ) {
+            for (int i = 0; i < count; i++) {
+                producer.send(SchemaData.protobufData);
+            }
+        }
+    }
+
     public void testSimpleSQL(String format, Map<String, String> extend) throws Exception {
         StreamExecutionEnvironment see = StreamExecutionEnvironment.getExecutionEnvironment();
         see.setParallelism(1);
@@ -374,58 +462,58 @@ public class FlinkPulsarTableITest extends PulsarTestBaseWithFlink {
         String extendParamStr = "";
         if (extend != null && !extend.isEmpty()) {
             extendParamStr = extend.entrySet().stream()
-                    .map(e -> String.format("'%s' = '%s'", e.getKey(), e.getValue()))
-                    .collect(Collectors.joining(",\n"));
+                .map(e -> String.format("'%s' = '%s'", e.getKey(), e.getValue()))
+                .collect(Collectors.joining(",\n"));
             extendParamStr += ",\n";
         }
         createTable = String.format(
-                "create table pulsar (\n" +
-                        "  id int, \n" +
-                        "  compute as id + 1, \n" +
-                        "  log_ts timestamp(3),\n" +
-                        "  ts as log_ts + INTERVAL '1' SECOND,\n" +
-                        "  watermark for ts as ts\n" +
-                        ") with (\n" +
-                        "  'connector' = 'pulsar',\n" +
-                        "  'topic' = '%s',\n" +
-                        "  'service-url' = '%s',\n" +
-                        "  'admin-url' = '%s',\n" +
-                        "  'scan.startup.mode' = 'earliest', \n" +
-                        "%s" +
-                        "  %s \n" +
-                        ")",
-                topic,
-                serviceUrl,
-                adminUrl,
-                extendParamStr,
-                String.format("'format' = '%s'", format));
+            "create table pulsar (\n" +
+                "  id int, \n" +
+                "  compute as id + 1, \n" +
+                "  log_ts timestamp(3),\n" +
+                "  ts as log_ts + INTERVAL '1' SECOND,\n" +
+                "  watermark for ts as ts\n" +
+                ") with (\n" +
+                "  'connector' = 'pulsar',\n" +
+                "  'topic' = '%s',\n" +
+                "  'service-url' = '%s',\n" +
+                "  'admin-url' = '%s',\n" +
+                "  'scan.startup.mode' = 'earliest', \n" +
+                "%s" +
+                "  %s \n" +
+                ")",
+            topic,
+            serviceUrl,
+            adminUrl,
+            extendParamStr,
+            String.format("'format' = '%s'", format));
 
         tEnv.executeSql(createTable).await();
         String initialValues = "INSERT INTO pulsar\n" +
-                "SELECT id, CAST(ts AS TIMESTAMP(3)) \n" +
-                "FROM (VALUES (1, '2019-12-12 00:00:01.001001'), \n" +
-                "  (2, '2019-12-12 00:00:01.001001'), \n" +
-                "  (3, '2019-12-12 00:00:01.001001'), \n" +
-                "  (4, '2019-12-12 00:00:01.001001'), \n" +
-                "  (5, '2019-12-12 00:00:01.001001'), \n" +
-                "  (6, '2019-12-12 00:00:01.001001'))\n" +
-                "  AS orders (id, ts)";
+            "SELECT id, CAST(ts AS TIMESTAMP(3)) \n" +
+            "FROM (VALUES (1, '2019-12-12 00:00:01.001001'), \n" +
+            "  (2, '2019-12-12 00:00:01.001001'), \n" +
+            "  (3, '2019-12-12 00:00:01.001001'), \n" +
+            "  (4, '2019-12-12 00:00:01.001001'), \n" +
+            "  (5, '2019-12-12 00:00:01.001001'), \n" +
+            "  (6, '2019-12-12 00:00:01.001001'))\n" +
+            "  AS orders (id, ts)";
         tEnv.executeSql(initialValues).await();
 
         // ---------- Consume stream from Pulsar -------------------
         System.out.println("Insert ok");
         String query = "SELECT \n" +
-                "  id + 1 \n" +
-                "FROM pulsar \n";
+            "  id + 1 \n" +
+            "FROM pulsar \n";
         DataStream<RowData> result = tEnv.toAppendStream(tEnv.sqlQuery(query), RowData.class);
         TestingSinkFunction sink = new TestingSinkFunction(6);
         result.addSink(sink).setParallelism(1);
         TestUtils.tryExecute(see, "Job_2");
 
         List<String> expected = Arrays.asList(
-                "+I(2)",
-                "+I(3)",
-                "+I(4)", "+I(5)", "+I(6)", "+I(7)");
+            "+I(2)",
+            "+I(3)",
+            "+I(4)", "+I(5)", "+I(6)", "+I(7)");
 
         assertEquals(expected, TestingSinkFunction.rows);
     }
@@ -440,51 +528,51 @@ public class FlinkPulsarTableITest extends PulsarTestBaseWithFlink {
 
         final String createTable;
         createTable = String.format(
-                "create table pulsar (\n" +
-                        "  `computed-price` as price + 1.0,\n" +
-                        "  price decimal(38, 18),\n" +
-                        "  currency string,\n" +
-                        "  log_date date,\n" +
-                        "  log_time time(3),\n" +
-                        "  log_ts timestamp(3),\n" +
-                        "  ts as log_ts + INTERVAL '1' SECOND,\n" +
-                        "  watermark for ts as ts\n" +
-                        ") with (\n" +
-                        "  'connector' = 'pulsar',\n" +
-                        "  'topic' = '%s',\n" +
-                        "  'service-url' = '%s',\n" +
-                        "  'admin-url' = '%s',\n" +
-                        "  'scan.startup.mode' = 'earliest', \n" +
-                        "  'format' ='avro' \n" +
-                        ")",
-                topic,
-                serviceUrl,
-                adminUrl);
+            "create table pulsar (\n" +
+                "  `computed-price` as price + 1.0,\n" +
+                "  price decimal(38, 18),\n" +
+                "  currency string,\n" +
+                "  log_date date,\n" +
+                "  log_time time(3),\n" +
+                "  log_ts timestamp(3),\n" +
+                "  ts as log_ts + INTERVAL '1' SECOND,\n" +
+                "  watermark for ts as ts\n" +
+                ") with (\n" +
+                "  'connector' = 'pulsar',\n" +
+                "  'topic' = '%s',\n" +
+                "  'service-url' = '%s',\n" +
+                "  'admin-url' = '%s',\n" +
+                "  'scan.startup.mode' = 'earliest', \n" +
+                "  'format' ='avro' \n" +
+                ")",
+            topic,
+            serviceUrl,
+            adminUrl);
         tEnv.executeSql(createTable);
 
         String initialValues = "INSERT INTO pulsar\n" +
-                "SELECT CAST(price AS DECIMAL(10, 2)), currency, " +
-                " CAST(d AS DATE), CAST(t AS TIME(0)), CAST(ts AS TIMESTAMP(3))\n" +
-                "FROM (VALUES (2.02,'Euro','2019-12-12', '00:00:01', '2019-12-12 00:00:01.001001'), \n" +
-                "  (1.11,'US Dollar','2019-12-12', '00:00:02', '2019-12-12 00:00:02.002001'), \n" +
-                "  (50,'Yen','2019-12-12', '00:00:03', '2019-12-12 00:00:03.004001'), \n" +
-                "  (3.1,'Euro','2019-12-12', '00:00:04', '2019-12-12 00:00:04.005001'), \n" +
-                "  (5.33,'US Dollar','2019-12-12', '00:00:05', '2019-12-12 00:00:05.006001'), \n" +
-                "  (0,'DUMMY','2019-12-12', '00:00:10', '2019-12-12 00:00:10'))\n" +
-                "  AS orders (price, currency, d, t, ts)";
+            "SELECT CAST(price AS DECIMAL(10, 2)), currency, " +
+            " CAST(d AS DATE), CAST(t AS TIME(0)), CAST(ts AS TIMESTAMP(3))\n" +
+            "FROM (VALUES (2.02,'Euro','2019-12-12', '00:00:01', '2019-12-12 00:00:01.001001'), \n" +
+            "  (1.11,'US Dollar','2019-12-12', '00:00:02', '2019-12-12 00:00:02.002001'), \n" +
+            "  (50,'Yen','2019-12-12', '00:00:03', '2019-12-12 00:00:03.004001'), \n" +
+            "  (3.1,'Euro','2019-12-12', '00:00:04', '2019-12-12 00:00:04.005001'), \n" +
+            "  (5.33,'US Dollar','2019-12-12', '00:00:05', '2019-12-12 00:00:05.006001'), \n" +
+            "  (0,'DUMMY','2019-12-12', '00:00:10', '2019-12-12 00:00:10'))\n" +
+            "  AS orders (price, currency, d, t, ts)";
         tEnv.executeSql(initialValues).await();
 
         // ---------- Consume stream from pulsar -------------------
         System.out.println("Insert ok");
         String query = "SELECT\n" +
-                "  CAST(TUMBLE_END(ts, INTERVAL '5' SECOND) AS VARCHAR),\n" +
-                "  CAST(MAX(log_date) AS VARCHAR),\n" +
-                "  CAST(MAX(log_time) AS VARCHAR),\n" +
-                "  CAST(MAX(ts) AS VARCHAR),\n" +
-                "  COUNT(*),\n" +
-                "  CAST(MAX(price) AS DECIMAL(10, 2))\n" +
-                "FROM pulsar\n" +
-                "GROUP BY TUMBLE(ts, INTERVAL '5' SECOND)";
+            "  CAST(TUMBLE_END(ts, INTERVAL '5' SECOND) AS VARCHAR),\n" +
+            "  CAST(MAX(log_date) AS VARCHAR),\n" +
+            "  CAST(MAX(log_time) AS VARCHAR),\n" +
+            "  CAST(MAX(ts) AS VARCHAR),\n" +
+            "  COUNT(*),\n" +
+            "  CAST(MAX(price) AS DECIMAL(10, 2))\n" +
+            "FROM pulsar\n" +
+            "GROUP BY TUMBLE(ts, INTERVAL '5' SECOND)";
 
         DataStream<RowData> result = tEnv.toAppendStream(tEnv.sqlQuery(query), RowData.class);
         TestingSinkFunction sink = new TestingSinkFunction(2);
@@ -493,8 +581,8 @@ public class FlinkPulsarTableITest extends PulsarTestBaseWithFlink {
         TestUtils.tryExecute(see, "Job_2");
 
         List<String> expected = Arrays.asList(
-                "+I(2019-12-12 00:00:05.000,2019-12-12,00:00:03,2019-12-12 00:00:04.004,3,50.00)",
-                "+I(2019-12-12 00:00:10.000,2019-12-12,00:00:05,2019-12-12 00:00:06.006,2,5.33)");
+            "+I(2019-12-12 00:00:05.000,2019-12-12,00:00:03,2019-12-12 00:00:04.004,3,50.00)",
+            "+I(2019-12-12 00:00:10.000,2019-12-12,00:00:05,2019-12-12 00:00:06.006,2,5.33)");
 
         assertEquals(expected, TestingSinkFunction.rows);
     }
@@ -508,38 +596,38 @@ public class FlinkPulsarTableITest extends PulsarTestBaseWithFlink {
 
         // ---------- Produce an event time stream into pulsar -------------------
         final String createTable = String.format(
-                "CREATE TABLE pulsar (\n"
-                        + "  `physical_1` STRING,\n"
-                        + "  `physical_2` INT,\n"
-                        // metadata fields are out of order on purpose
-                        // offset is ignored because it might not be deterministic
-                        + "  `eventTime` TIMESTAMP(3) METADATA,\n"
-                        + "  `properties` MAP<STRING, STRING> METADATA ,\n"
-                        + "  `topic` STRING METADATA VIRTUAL,\n"
-                        + "  `sequenceId` BIGINT METADATA VIRTUAL,\n"
-                        + "  `key` STRING ,\n"
-                        + "  `physical_3` BOOLEAN\n"
-                        + ") WITH (\n"
-                        + "  'connector' = 'pulsar',\n"
-                        + "  'topic' = '%s',\n"
-                        + "  'key.format' = 'raw',\n"
-                        + "  'key.fields' = 'key',\n"
-                        + "  'value.format' = 'avro',\n"
-                        + "  'service-url' = '%s',\n"
-                        + "  'admin-url' = '%s',\n"
-                        + "  'scan.startup.mode' = 'earliest' \n"
-                        + ")",
-                topic,
-                serviceUrl,
-                adminUrl);
+            "CREATE TABLE pulsar (\n"
+                + "  `physical_1` STRING,\n"
+                + "  `physical_2` INT,\n"
+                // metadata fields are out of order on purpose
+                // offset is ignored because it might not be deterministic
+                + "  `eventTime` TIMESTAMP(3) METADATA,\n"
+                + "  `properties` MAP<STRING, STRING> METADATA ,\n"
+                + "  `topic` STRING METADATA VIRTUAL,\n"
+                + "  `sequenceId` BIGINT METADATA VIRTUAL,\n"
+                + "  `key` STRING ,\n"
+                + "  `physical_3` BOOLEAN\n"
+                + ") WITH (\n"
+                + "  'connector' = 'pulsar',\n"
+                + "  'topic' = '%s',\n"
+                + "  'key.format' = 'raw',\n"
+                + "  'key.fields' = 'key',\n"
+                + "  'value.format' = 'avro',\n"
+                + "  'service-url' = '%s',\n"
+                + "  'admin-url' = '%s',\n"
+                + "  'scan.startup.mode' = 'earliest' \n"
+                + ")",
+            topic,
+            serviceUrl,
+            adminUrl);
 
         tEnv.executeSql(createTable);
 
         String initialValues = "INSERT INTO pulsar \n"
-                + "VALUES\n"
-                + " ('data 1', 1, TIMESTAMP '2020-03-08 13:12:11.123', MAP['k11', 'v11', 'k12', 'v12'], 'key1', TRUE),\n"
-                + " ('data 2', 2, TIMESTAMP '2020-03-09 13:12:11.123', MAP['k21', 'v21', 'k22', 'v22'], 'key2', FALSE),\n"
-                + " ('data 3', 3, TIMESTAMP '2020-03-10 13:12:11.123', MAP['k31', 'v31', 'k32', 'v32'], 'key3', TRUE)";
+            + "VALUES\n"
+            + " ('data 1', 1, TIMESTAMP '2020-03-08 13:12:11.123', MAP['k11', 'v11', 'k12', 'v12'], 'key1', TRUE),\n"
+            + " ('data 2', 2, TIMESTAMP '2020-03-09 13:12:11.123', MAP['k21', 'v21', 'k22', 'v22'], 'key2', FALSE),\n"
+            + " ('data 3', 3, TIMESTAMP '2020-03-10 13:12:11.123', MAP['k31', 'v31', 'k32', 'v32'], 'key3', TRUE)";
 
         tEnv.executeSql(initialValues).await();
 
@@ -560,9 +648,9 @@ public class FlinkPulsarTableITest extends PulsarTestBaseWithFlink {
         headers3.put("k32", "v32");
 
         final List<Row> expected = Arrays.asList(
-                Row.of("data 1", 1, LocalDateTime.parse("2020-03-08T13:12:11.123"), headers1, topic, 0L, "key1", true),
-                Row.of("data 2", 2, LocalDateTime.parse("2020-03-09T13:12:11.123"), headers2, topic, 1L, "key2", false),
-                Row.of("data 3", 3, LocalDateTime.parse("2020-03-10T13:12:11.123"), headers3, topic, 2L, "key3", true)
+            Row.of("data 1", 1, LocalDateTime.parse("2020-03-08T13:12:11.123"), headers1, topic, 0L, "key1", true),
+            Row.of("data 2", 2, LocalDateTime.parse("2020-03-09T13:12:11.123"), headers2, topic, 1L, "key2", false),
+            Row.of("data 3", 3, LocalDateTime.parse("2020-03-10T13:12:11.123"), headers3, topic, 2L, "key3", true)
         );
 
         assertThat(result, deepEqualTo(expected, true));
@@ -589,43 +677,43 @@ public class FlinkPulsarTableITest extends PulsarTestBaseWithFlink {
         }
 
         List<MessageId> messageIdList =
-                sendTypedMessagesWithMetadata(topic, SchemaType.INT32,
-                        SchemaData.INTEGER_LIST, Optional.empty(),
-                        null, eventTimes, sequenceIds, properties, keys);
+            sendTypedMessagesWithMetadata(topic, SchemaType.INT32,
+                SchemaData.INTEGER_LIST, Optional.empty(),
+                null, eventTimes, sequenceIds, properties, keys);
         List<Row> expected = new ArrayList<>();
         for (int i = 0; i < SchemaData.INTEGER_LIST.size(); i++) {
             Timestamp timestamp = new Timestamp(eventTimes.get(i));
             LocalDateTime localDateTime = timestamp.toLocalDateTime();
             expected.add(Row.of(SchemaData.INTEGER_LIST.get(i), localDateTime,
-                    properties.get(i), topic, keys.get(i), sequenceIds.get(i)));
+                properties.get(i), topic, keys.get(i), sequenceIds.get(i)));
         }
 
         // ---------- Produce an event time stream into pulsar -------------------
         final String createTable = String.format(
-                "CREATE TABLE pulsar (\n"
-                        + "  `physical_1` INT,\n"
-                        // metadata fields are out of order on purpose
-                        // offset is ignored because it might not be deterministic
+            "CREATE TABLE pulsar (\n"
+                + "  `physical_1` INT,\n"
+                // metadata fields are out of order on purpose
+                // offset is ignored because it might not be deterministic
 //                        + "  `messageId` BYTES METADATA,\n"
-                        + "  `eventTime` TIMESTAMP(3) METADATA,\n"
-                        + "  `properties` MAP<STRING, STRING> METADATA ,\n"
-                        + "  `topic` STRING METADATA VIRTUAL,\n"
-                        + "  `key` STRING ,\n"
-                        + "  `sequenceId` BIGINT METADATA VIRTUAL\n"
-                        + ") WITH (\n"
-                        + "  'connector' = 'pulsar',\n"
-                        + "  'topic' = '%s',\n"
-                        + "  'service-url' = '%s',\n"
-                        + "  'admin-url' = '%s',\n"
-                        + "  'value.fields-include' = 'EXCEPT_KEY', \n"
-                        + "  'key.format' = 'raw',\n"
-                        + "  'key.fields' = 'key',\n"
-                        + "  'value.format' = 'atomic',\n"
-                        + " 'scan.startup.mode' = 'earliest' \n"
-                        + ")",
-                topic,
-                serviceUrl,
-                adminUrl);
+                + "  `eventTime` TIMESTAMP(3) METADATA,\n"
+                + "  `properties` MAP<STRING, STRING> METADATA ,\n"
+                + "  `topic` STRING METADATA VIRTUAL,\n"
+                + "  `key` STRING ,\n"
+                + "  `sequenceId` BIGINT METADATA VIRTUAL\n"
+                + ") WITH (\n"
+                + "  'connector' = 'pulsar',\n"
+                + "  'topic' = '%s',\n"
+                + "  'service-url' = '%s',\n"
+                + "  'admin-url' = '%s',\n"
+                + "  'value.fields-include' = 'EXCEPT_KEY', \n"
+                + "  'key.format' = 'raw',\n"
+                + "  'key.fields' = 'key',\n"
+                + "  'value.format' = 'atomic',\n"
+                + " 'scan.startup.mode' = 'earliest' \n"
+                + ")",
+            topic,
+            serviceUrl,
+            adminUrl);
         tEnv.executeSql(createTable);
 
         final List<Row> result = PulsarTableTestUtils.collectRows(tEnv.sqlQuery("SELECT * FROM pulsar"), 5);

--- a/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/SchemaData.java
+++ b/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/SchemaData.java
@@ -14,13 +14,17 @@
 
 package org.apache.flink.streaming.connectors.pulsar;
 
+import com.google.protobuf.Descriptors;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.pulsar.client.impl.schema.ProtobufNativeSchemaUtils;
 
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -48,6 +52,8 @@ public class SchemaData {
     public static List<Foo> fooList;
     public static List<FL> flList;
     public static List<FM> fmList;
+    public static byte[] protobufData;
+    public static Descriptors.Descriptor descriptor;
 
     static {
         localDateList = INTEGER_LIST.stream()
@@ -83,6 +89,9 @@ public class SchemaData {
                 new FM(Collections.singletonMap("b", new Bar(false, "b"))),
                 new FM(Collections.singletonMap("c", new Bar(true, "a")))
         );
+        String schema =  "{\"fileDescriptorSet\":\"CpUDChJzaW1wbGVfdGVzdDEucHJvdG8SK29yZy5hcGFjaGUuZmxpbmsuZm9ybWF0cy5wcm90b2J1Zi50ZXN0cHJvdG8ioAIKC1NpbXBsZVRlc3QxEg0KAWEYASABKAU6AjEwEg4KAWIYAiABKAM6AzEwMBIJCgFjGAMgASgIEgkKAWQYBCABKAISCQoBZRgFIAEoARIMCgFmGAYgASgJOgFmEgkKAWcYByABKAwSSgoBaBgIIAEoDjI/Lm9yZy5hcGFjaGUuZmxpbmsuZm9ybWF0cy5wcm90b2J1Zi50ZXN0cHJvdG8uU2ltcGxlVGVzdDEuQ29ycHVzEhAKCGZfYWJjXzdkGAkgASgFIloKBkNvcnB1cxINCglVTklWRVJTQUwQABIHCgNXRUIQARIKCgZJTUFHRVMQAhIJCgVMT0NBTBADEggKBE5FV1MQBBIMCghQUk9EVUNUUxAFEgkKBVZJREVPEAdCLworb3JnLmFwYWNoZS5mbGluay5mb3JtYXRzLnByb3RvYnVmLnRlc3Rwcm90b1AB\",\"rootMessageTypeName\":\"org.apache.flink.formats.protobuf.testproto.SimpleTest1\",\"rootFileDescriptorName\":\"simple_test1.proto\"}";
+        descriptor = ProtobufNativeSchemaUtils.deserialize(schema.getBytes(StandardCharsets.UTF_8));
+        protobufData = Base64.getDecoder().decode("CAEQAhgAJc3MzD0pexSuR+F6hD8yBGhhaGE6AQFAAkgB");
     }
 
 


### PR DESCRIPTION
### NOTE

Based on Pulsar ProtobufNative Schema, the `pulsar-protobuf-native` Flink format is defined. It supports the use of Descriptor defined in ProtobufNative Schema to parse messages into RowData format.

`pulsar-protobuf-native` depends on the **topic, adminUrl and properties** configurations in the pulsar connector.

- The decoding implementation class of `pulsar-protobuf-native`, `PulsarProtobufNativeRowDataDeserializationSchema`, will use the topic, adminUrl and properties  to obtain the Pulsar Schema when it is opened.
- Now only supports single Topic TableSource.
--------------

### Motivation

Support ProtobufNative Schema TableSource format.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no )
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation (no)