### PR TITLE
fix state for flink 1.9

### DIFF
--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/MessageIdSerializer.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/MessageIdSerializer.java
@@ -1,0 +1,123 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.connectors.pulsar.internal;
+
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import org.apache.pulsar.client.api.MessageId;
+
+import java.io.IOException;
+
+/**
+ * MessageId Serializer for flink state.
+ */
+public class MessageIdSerializer extends TypeSerializer<MessageId> {
+
+    public static final MessageIdSerializer INSTANCE = new MessageIdSerializer();
+
+    @Override
+    public boolean isImmutableType() {
+        return true;
+    }
+
+    @Override
+    public TypeSerializer<MessageId> duplicate() {
+        return this;
+    }
+
+    @Override
+    public MessageId createInstance() {
+        return MessageId.earliest;
+    }
+
+    @Override
+    public MessageId copy(MessageId from) {
+        try {
+            return MessageId.fromByteArray(from.toByteArray());
+        } catch (IOException e) {
+            throw new IllegalStateException("MessageId copy should not throw an exception", e);
+        }
+    }
+
+    @Override
+    public MessageId copy(MessageId from, MessageId reuse) {
+        return copy(from);
+    }
+
+    @Override
+    public int getLength() {
+        return -1;
+    }
+
+    @Override
+    public void serialize(MessageId record, DataOutputView target) throws IOException {
+        target.write(record.toByteArray());
+    }
+
+    @Override
+    public MessageId deserialize(DataInputView source) throws IOException {
+        int length = source.readInt();
+        byte[] bytes = new byte[length];
+        source.readFully(bytes);
+        return MessageId.fromByteArray(bytes);
+    }
+
+    @Override
+    public MessageId deserialize(MessageId reuse, DataInputView source) throws IOException {
+        return deserialize(source);
+    }
+
+    @Override
+    public void copy(DataInputView source, DataOutputView target) throws IOException {
+        serialize(deserialize(source), target);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj != null && this.getClass() == obj.getClass()) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return this.getClass().hashCode();
+    }
+
+    @Override
+    public TypeSerializerSnapshot<MessageId> snapshotConfiguration() {
+        return new MessageIdSerializerSnapshot();
+    }
+
+    // ------------------------------------------------------------------------
+
+    /**
+     * Serializer configuration snapshot for compatibility and format evolution.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final class MessageIdSerializerSnapshot extends SimpleTypeSerializerSnapshot<MessageId> {
+
+        public MessageIdSerializerSnapshot() {
+            super(() -> INSTANCE);
+        }
+    }
+}

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarByteArraySerializer.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarByteArraySerializer.java
@@ -1,0 +1,137 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar.internal;
+
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+
+/**
+ * PulsarByteArraySerializer.
+ */
+public class PulsarByteArraySerializer extends TypeSerializer<byte[]> implements TypeSerializerConfigSnapshot.SelfResolvingTypeSerializer<byte[]> {
+
+    private static final byte[] EMPTY = new byte[0];
+
+    public static final PulsarByteArraySerializer INSTANCE = new PulsarByteArraySerializer();
+
+    @Override
+    public TypeSerializerSchemaCompatibility<byte[]> resolveSchemaCompatibilityViaRedirectingToNewSnapshotClass(TypeSerializerConfigSnapshot<byte[]> deprecatedConfigSnapshot) {
+        return TypeSerializerSchemaCompatibility.compatibleWithReconfiguredSerializer(this);
+    }
+
+    @Override
+    public boolean isImmutableType() {
+        return false;
+    }
+
+    @Override
+    public TypeSerializer<byte[]> duplicate() {
+        return INSTANCE;
+    }
+
+    @Override
+    public byte[] createInstance() {
+        return EMPTY;
+    }
+
+    @Override
+    public byte[] copy(byte[] from) {
+        byte[] copy = new byte[from.length];
+        System.arraycopy(from, 0, copy, 0, from.length);
+        return copy;
+    }
+
+    @Override
+    public byte[] copy(byte[] from, byte[] reuse) {
+        return copy(from);
+    }
+
+    @Override
+    public int getLength() {
+        return -1;
+    }
+
+    @Override
+    public void serialize(byte[] record, DataOutputView target) throws IOException {
+        if (record == null) {
+            throw new IllegalArgumentException("The record must not be null.");
+        }
+
+        final int len = record.length;
+        target.writeInt(len);
+        target.write(record);
+    }
+
+    @Override
+    public byte[] deserialize(DataInputView source) throws IOException {
+        final int len = source.readInt();
+        byte[] result = new byte[len];
+        source.readFully(result);
+        return result;
+    }
+
+    @Override
+    public byte[] deserialize(byte[] reuse, DataInputView source) throws IOException {
+        return deserialize(source);
+    }
+
+    @Override
+    public void copy(DataInputView source, DataOutputView target) throws IOException {
+        final int len = source.readInt();
+        target.writeInt(len);
+        target.write(source, len);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj != null && this.getClass() == obj.getClass()) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return this.getClass().hashCode();
+    }
+
+    @Override
+    public TypeSerializerSnapshot<byte[]> snapshotConfiguration() {
+        return new PulsarByteArraySerializerSnapshot();
+    }
+
+    // ------------------------------------------------------------------------
+
+    /**
+     * Serializer configuration snapshot for compatibility and format evolution.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final class PulsarByteArraySerializerSnapshot extends SimpleTypeSerializerSnapshot<byte[]> {
+
+        public PulsarByteArraySerializerSnapshot() {
+            super(() -> INSTANCE);
+        }
+    }
+}

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarSourceStateSerializer.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarSourceStateSerializer.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.connectors.pulsar.internal;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.core.memory.DataInputDeserializer;
+
+import org.apache.pulsar.client.api.MessageId;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
+
+/**
+ * Old PulsarSourceState Serializer for flink state.
+ */
+public class PulsarSourceStateSerializer implements SimpleVersionedSerializer<Tuple2<TopicRange, MessageId>>, Serializable {
+
+    private static final int CURRENT_VERSION = 0;
+
+    private final ExecutionConfig executionConfig;
+
+    public PulsarSourceStateSerializer(ExecutionConfig executionConfig) {
+        this.executionConfig = executionConfig;
+    }
+
+    @Override
+    public int getVersion() {
+        return CURRENT_VERSION;
+    }
+
+    @Override
+    public byte[] serialize(Tuple2<TopicRange, MessageId> obj) throws IOException {
+        throw new UnsupportedEncodingException("for Pulsar source state migration only");
+    }
+
+    @Override
+    public Tuple2<TopicRange, MessageId> deserialize(int version, byte[] serialized) throws IOException {
+        final DataInputDeserializer deserializer = new DataInputDeserializer(serialized);
+        try {
+            return getV1Serializer().deserialize(deserializer);
+        } catch (IOException e) {
+            Tuple2<String, MessageId> deserialize = getV0Serializer().deserialize(deserializer);
+            return Tuple2.of(new TopicRange(deserialize.f0), deserialize.f1);
+        }
+    }
+
+    public TupleSerializer<Tuple2<String, MessageId>> getV0Serializer() {
+        TypeSerializer<?>[] fieldSerializers =
+                new TypeSerializer<?>[]{
+                        StringSerializer.INSTANCE,
+                        new KryoSerializer<>(MessageId.class, executionConfig)
+                };
+        @SuppressWarnings("unchecked")
+        Class<Tuple2<String, MessageId>> tupleClass =
+                (Class<Tuple2<String, MessageId>>) (Class<?>) Tuple2.class;
+        return new TupleSerializer<>(tupleClass, fieldSerializers);
+    }
+
+    public TupleSerializer<Tuple2<TopicRange, MessageId>> getV1Serializer() {
+        TypeSerializer<?>[] fieldSerializers =
+                new TypeSerializer<?>[]{
+                        new KryoSerializer<>(TopicRange.class, executionConfig),
+                        new KryoSerializer<>(MessageId.class, executionConfig)
+                };
+        @SuppressWarnings("unchecked")
+        Class<Tuple2<TopicRange, MessageId>> tupleClass =
+                (Class<Tuple2<TopicRange, MessageId>>) (Class<?>) Tuple2.class;
+        return new TupleSerializer<>(tupleClass, fieldSerializers);
+    }
+}

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/TopicSubscription.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/TopicSubscription.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.connectors.pulsar.internal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TopicSubscription implements Serializable {
+
+	private String topic;
+
+	private SerializableRange range;
+
+	private String subscriptionName;
+}

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/TopicSubscriptionSerializer.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/TopicSubscriptionSerializer.java
@@ -1,0 +1,131 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.connectors.pulsar.internal;
+
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * TopicSubscription Serializer for flink state.
+ */
+public class TopicSubscriptionSerializer extends TypeSerializer<TopicSubscription> {
+
+    public static final TopicSubscriptionSerializer INSTANCE = new TopicSubscriptionSerializer();
+
+    @Override
+    public boolean isImmutableType() {
+        return true;
+    }
+
+    @Override
+    public TypeSerializer<TopicSubscription> duplicate() {
+        return this;
+    }
+
+    @Override
+    public TopicSubscription createInstance() {
+        return new TopicSubscription();
+    }
+
+    @Override
+    public TopicSubscription copy(TopicSubscription from) {
+        return TopicSubscription.builder()
+                .topic(from.getTopic())
+                .subscriptionName(from.getSubscriptionName())
+                .range(from.getRange())
+                .build();
+    }
+
+    @Override
+    public TopicSubscription copy(TopicSubscription from, TopicSubscription reuse) {
+        return copy(from);
+    }
+
+    @Override
+    public int getLength() {
+        return -1;
+    }
+
+    @Override
+    public void serialize(TopicSubscription record, DataOutputView target) throws IOException {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             ObjectOutputStream out = new ObjectOutputStream(baos)) {
+            out.writeObject(record);
+            out.flush();
+            target.write(baos.toByteArray());
+        }
+    }
+
+    @Override
+    public TopicSubscription deserialize(DataInputView source) throws IOException {
+        int length = source.readInt();
+        byte[] serialized = new byte[length];
+        source.readFully(serialized);
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
+             ObjectInputStream in = new ObjectInputStream(bais)) {
+            try {
+                return (TopicSubscription) in.readObject();
+            } catch (ClassNotFoundException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
+    @Override
+    public TopicSubscription deserialize(TopicSubscription reuse, DataInputView source) throws IOException {
+        return deserialize(source);
+    }
+
+    @Override
+    public void copy(DataInputView source, DataOutputView target) throws IOException {
+        serialize(deserialize(source), target);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+
+    @Override
+    public TypeSerializerSnapshot<TopicSubscription> snapshotConfiguration() {
+        return new TopicSubscriptionSerializer.TopicSubscriptionSerializerSnapshot();
+    }
+
+    // ------------------------------------------------------------------------
+
+    /**
+     * Serializer configuration snapshot for compatibility and format evolution.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final class TopicSubscriptionSerializerSnapshot extends SimpleTypeSerializerSnapshot<TopicSubscription> {
+
+        public TopicSubscriptionSerializerSnapshot() {
+            super(() -> INSTANCE);
+        }
+    }
+}


### PR DESCRIPTION
This version is mainly used to migrate checkpoint state. Due to the limitation of Flink state, there is no way to read the old version state into bytes at runtime.