### PR TITLE
fix Avro schema decode errors when working with partitioned topics + ddl

### DIFF
--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/util/serialization/PulsarDeserializationSchema.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/util/serialization/PulsarDeserializationSchema.java
@@ -73,8 +73,6 @@ public interface PulsarDeserializationSchema<T> extends PulsarContextAware<T>, S
     default void open(DeserializationSchema.InitializationContext context) throws Exception {
     }
 
-    ;
-
     /**
      * Method to decide whether the element signals the end of the stream. If
      * true is returned the element won't be emitted.
@@ -84,8 +82,6 @@ public interface PulsarDeserializationSchema<T> extends PulsarContextAware<T>, S
      * @return True, if the element signals end of stream, false otherwise.
      */
     boolean isEndOfStream(T nextElement);
-
-    ;
 
     /**
      * Deserializes the Pulsar message.


### PR DESCRIPTION
fixed #251 

TODO: add test Coverage

Because the Pulsar Source internal is designed to be multi-threaded and Flink's internal design of the Source is single-threaded,
so, DeserializationSchema instances are oriented to single-threaded, thread safety issues exist when they are accessed by multiple threads at the same time. Cause the message deserialization to fail.