### PR TITLE
fix release

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,8 +18,7 @@ on:
     branches:
       - master
 jobs:
-
-  unit-tests-scala-2_11:
+  unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
@@ -45,40 +44,8 @@ jobs:
           sudo cp -R protoc/include/* $BASE/include
       - name: Run check and test
         run: |
-          ./tools/retry.sh mvn -B -ntp clean install -Pscala-2.11
+          ./tools/retry.sh mvn -B -ntp clean install
 
-  unit-tests-scala-2_12:
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-      - name: install protoc
-        run: |
-          sudo -E apt update && sudo -E apt install -y wget
-          cd /tmp
-          mkdir protoc
-          wget -O protoc-3.15.5-linux-x86_64.zip https://github.com/protocolbuffers/protobuf/releases/download/v3.15.5/protoc-3.15.5-linux-x86_64.zip
-          unzip protoc-3.15.5-linux-x86_64.zip -d protoc
-          chmod 755 -R protoc
-          BASE=/usr/local
-          sudo rm -rf $BASE/include/google/protobuf/
-          sudo cp protoc/bin/protoc $BASE/bin
-          sudo cp -R protoc/include/* $BASE/include
-      - name: Run check and test
-        run: |
-          ./tools/retry.sh mvn -B -ntp clean install -Pscala-2.11
-
-      - name: Run check and test
-        run: |
-          mvn -pl flink-protobuf test-compile jar:test-jar install
-          ./tools/retry.sh mvn -B -ntp clean install -Pscala-2.12
   unit-tests-local:
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/flink-protobuf/pom.xml
+++ b/flink-protobuf/pom.xml
@@ -17,9 +17,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-protobuf/pom.xml
+++ b/flink-protobuf/pom.xml
@@ -36,7 +36,6 @@ under the License.
 	<properties>
 		<janino.version>3.0.11</janino.version>
 		<protoc.version>3.11.1</protoc.version>
-		<flink.version>1.12.1</flink.version>
 		<checkstyle.skip>true</checkstyle.skip>
 		<license.skip>true</license.skip>
 		<spotbugs.skip>true</spotbugs.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -71,15 +71,17 @@
     <javac.target>1.8</javac.target>
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
     <testRetryCount>2</testRetryCount>
-    <scala.binary.version>2.11</scala.binary.version>
 
     <!-- use Pulsar stable version -->
     <pulsar.version>2.7.0</pulsar.version>
+    <flink.version>1.12.1</flink.version>
+    <flink.binary.version>1.12</flink.binary.version>
+    <scala.binary.version>2.11</scala.binary.version>
     <testcontainers.version>1.15.2</testcontainers.version>
     <powermock.version>2.0.2</powermock.version>
     <mockito.version>3.7.7</mockito.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <junit.version>4.12</junit.version>
+    <junit.version>4.13.2</junit.version>
     <jackson.version>2.10.5.1</jackson.version>
     <!-- plugin dependencies -->
     <maven.version>3.5.4</maven.version>
@@ -144,7 +146,6 @@
     </pluginManagement>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven-compiler-plugin.version}</version>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,8 @@
     <module>flink-protobuf</module>
     <module>managed-ledger-shaded</module>
     <module>pulsar-flink-connector</module>
+    <module>pulsar-flink-connector-shade-2.11</module>
+    <module>pulsar-flink-connector-shade-2.12</module>
   </modules>
 
   <parent>
@@ -77,6 +79,7 @@
     <powermock.version>2.0.2</powermock.version>
     <mockito.version>3.7.7</mockito.version>
     <hamcrest.version>1.3</hamcrest.version>
+    <junit.version>4.12</junit.version>
     <jackson.version>2.10.5.1</jackson.version>
     <!-- plugin dependencies -->
     <maven.version>3.5.4</maven.version>
@@ -122,47 +125,13 @@
       <artifactId>aircompressor</artifactId>
       <version>0.16</version>
     </dependency>
-
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-      <version>${hamcrest.version}</version>
-      <type>jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>testcontainers</artifactId>
-      <version>${testcontainers.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>pulsar</artifactId>
-      <version>${testcontainers.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>${mockito.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-
   <build>
     <pluginManagement>
       <plugins>
@@ -175,6 +144,7 @@
     </pluginManagement>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven-compiler-plugin.version}</version>
         <configuration>

--- a/pulsar-flink-connector-shade-2.11/pom.xml
+++ b/pulsar-flink-connector-shade-2.11/pom.xml
@@ -1,0 +1,154 @@
+<!--
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>pulsar-flink-parent</artifactId>
+        <groupId>io.streamnative.connectors</groupId>
+        <version>2.7.6-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>pulsar-flink-connector-${scala.binary.version}-${flink.binary.version}</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <flink.version>1.12.1</flink.version>
+        <flink.binary.version>1.12</flink.binary.version>
+        <scala.version>2.11.12</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
+        <license.skip>true</license.skip>
+        <spotbugs.skip>true</spotbugs.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.streamnative.connectors</groupId>
+            <artifactId>flink-protobuf</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.streamnative.connectors</groupId>
+            <artifactId>pulsar-flink-connector-origin-1.12</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-common</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-json</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-avro</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <!-- Shade all the dependencies to avoid conflicts -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                            <minimizeJar>false</minimizeJar>
+
+                            <artifactSet>
+                                <includes>
+                                    <include>io.streamnative.connectors:flink-protobuf</include>
+                                    <include>io.streamnative.connectors:pulsar-flink-connector-origin*</include>
+                                    <include>org.apache.pulsar:*</include>
+                                    <include>org.apache.flink:flink-avro</include>
+                                    <include>org.apache.avro:avro</include>
+                                    <include>org.apache.flink:flink-json</include>
+                                    <include>com.fasterxml.jackson.core:jackson-*</include>
+                                    <include>org.bouncycastle*:*</include>
+                                    <include>org.bouncycastle*:*</include>
+                                    <include>javax.*:*</include>
+                                    <include>org.lz4*:*</include>
+                                    <include>commons-collections:commons-collections</include>
+                                    <include>org.slf4j:jul-to-slf4j</include>
+                                    <include>io.airlift:*</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>
+                                        io.streamnative.connectors:pulsar-flink-connector_${scala.binary.version}
+                                    </artifact>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                </filter>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/NOTICE.txt</exclude>
+                                        <exclude>META-INF/NOTICE</exclude>
+                                        <exclude>META-INF/LICENSE.txt</exclude>
+                                        <exclude>META-INF/LICENSE</exclude>
+                                        <exclude>META-INF/DEPENDENCIES</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>org.apache.pulsar.shade.com.google</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons</pattern>
+                                    <shadedPattern>org.apache.pulsar.shade.org.apache.commons</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.PluginXmlResourceTransformer" />
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/pulsar-flink-connector-shade-2.11/pom.xml
+++ b/pulsar-flink-connector-shade-2.11/pom.xml
@@ -25,8 +25,6 @@
     <packaging>jar</packaging>
 
     <properties>
-        <flink.version>1.12.1</flink.version>
-        <flink.binary.version>1.12</flink.binary.version>
         <scala.version>2.11.12</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
         <license.skip>true</license.skip>
@@ -41,7 +39,7 @@
         </dependency>
         <dependency>
             <groupId>io.streamnative.connectors</groupId>
-            <artifactId>pulsar-flink-connector-origin-1.12</artifactId>
+            <artifactId>pulsar-flink-connector-origin-${flink.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/pulsar-flink-connector-shade-2.12/pom.xml
+++ b/pulsar-flink-connector-shade-2.12/pom.xml
@@ -25,8 +25,6 @@
     <packaging>jar</packaging>
 
     <properties>
-        <flink.version>1.12.1</flink.version>
-        <flink.binary.version>1.12</flink.binary.version>
         <scala.version>2.12.7</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <license.skip>true</license.skip>
@@ -41,7 +39,7 @@
         </dependency>
         <dependency>
             <groupId>io.streamnative.connectors</groupId>
-            <artifactId>pulsar-flink-connector-origin-1.12</artifactId>
+            <artifactId>pulsar-flink-connector-origin-${flink.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/pulsar-flink-connector-shade-2.12/pom.xml
+++ b/pulsar-flink-connector-shade-2.12/pom.xml
@@ -1,0 +1,134 @@
+<!--
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>pulsar-flink-parent</artifactId>
+        <groupId>io.streamnative.connectors</groupId>
+        <version>2.7.6-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>pulsar-flink-connector-${scala.binary.version}-${flink.binary.version}</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <flink.version>1.12.1</flink.version>
+        <flink.binary.version>1.12</flink.binary.version>
+        <scala.version>2.12.7</scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
+        <license.skip>true</license.skip>
+        <spotbugs.skip>true</spotbugs.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.streamnative.connectors</groupId>
+            <artifactId>flink-protobuf</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.streamnative.connectors</groupId>
+            <artifactId>pulsar-flink-connector-origin-1.12</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-json</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-avro</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <!-- Shade all the dependencies to avoid conflicts -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                            <minimizeJar>false</minimizeJar>
+
+                            <artifactSet>
+                                <includes>
+                                    <include>io.streamnative.connectors:flink-protobuf</include>
+                                    <include>io.streamnative.connectors:pulsar-flink-connector-origin*</include>
+                                    <include>org.apache.pulsar:*</include>
+                                    <include>org.apache.flink:flink-avro</include>
+                                    <include>org.apache.avro:avro</include>
+                                    <include>org.apache.flink:flink-json</include>
+                                    <include>com.fasterxml.jackson.core:jackson-*</include>
+                                    <include>org.bouncycastle*:*</include>
+                                    <include>javax.*:*</include>
+                                    <include>org.lz4*:*</include>
+                                    <include>commons-collections:commons-collections</include>
+                                    <include>org.slf4j:jul-to-slf4j</include>
+                                    <include>io.airlift:*</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/NOTICE.txt</exclude>
+                                        <exclude>META-INF/NOTICE</exclude>
+                                        <exclude>META-INF/LICENSE.txt</exclude>
+                                        <exclude>META-INF/LICENSE</exclude>
+                                        <exclude>META-INF/DEPENDENCIES</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>org.apache.pulsar.shade.com.google</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons</pattern>
+                                    <shadedPattern>org.apache.pulsar.shade.org.apache.commons</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.PluginXmlResourceTransformer" />
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/pulsar-flink-connector/pom.xml
+++ b/pulsar-flink-connector/pom.xml
@@ -25,8 +25,6 @@
   <packaging>jar</packaging>
 
   <properties>
-    <flink.version>1.12.1</flink.version>
-    <flink.binary.version>1.12</flink.binary.version>
     <protoc.version>3.11.1</protoc.version>
   </properties>
 

--- a/pulsar-flink-connector/pom.xml
+++ b/pulsar-flink-connector/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>pulsar-flink-connector-${scala.binary.version}-${flink.binary.version}</artifactId>
+  <artifactId>pulsar-flink-connector-origin-${flink.binary.version}</artifactId>
   <packaging>jar</packaging>
 
   <properties>
@@ -210,76 +210,47 @@
       <artifactId>slf4j-log4j12</artifactId>
       <version>1.7.25</version>
     </dependency>
-  </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <!-- Shade all the dependencies to avoid conflicts -->
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <createDependencyReducedPom>true</createDependencyReducedPom>
-              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
-              <minimizeJar>false</minimizeJar>
 
-              <artifactSet>
-                <includes>
-                  <include>com.github.luben:*</include>
-                  <include>javax.*:*</include>
-                  <include>org.apache.pulsar*:*</include>
-                  <include>org.apache.flink:flink-avro</include>
-                  <include>org.apache.flink:flink-json</include>
-                  <include>org.apache.avro:avro</include>
-                  <include>com.fasterxml.jackson.core:jackson*</include>
-                  <include>org.bouncycastle*:*</include>
-                  <include>org.lz4*:*</include>
-                  <include>commons-collections:commons-collections</include>
-                  <include>org.slf4j:jul-to-slf4j</include>
-                  <include>io.airlift:*</include>
-                </includes>
-              </artifactSet>
-              <filters>
-                <filter>
-                  <artifact>
-                    io.streamnative.connectors:pulsar-flink-connector_${scala.binary.version}
-                  </artifact>
-                  <includes>
-                    <include>**</include>
-                  </includes>
-                </filter>
-                <filter>
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/*.SF</exclude>
-                    <exclude>META-INF/*.DSA</exclude>
-                    <exclude>META-INF/*.RSA</exclude>
-                  </excludes>
-                </filter>
-              </filters>
-              <relocations>
-                <relocation>
-                  <pattern>com.google</pattern>
-                  <shadedPattern>org.apache.pulsar.shade.com.google</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.commons</pattern>
-                  <shadedPattern>org.apache.pulsar.shade.org.apache.commons</shadedPattern>
-                </relocation>
-              </relocations>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                <transformer implementation="org.apache.maven.plugins.shade.resource.PluginXmlResourceTransformer" />
-              </transformers>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>${hamcrest.version}</version>
+      <type>jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>pulsar</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+<build>
+  <plugins>
       <plugin>
         <groupId>com.github.os72</groupId>
         <artifactId>protoc-jar-maven-plugin</artifactId>
@@ -301,84 +272,4 @@
       </plugin>
     </plugins>
   </build>
-  <profiles>
-    <profile>
-      <id>scala-2.11</id>
-      <properties>
-        <scala.version>2.11.12</scala.version>
-        <scala.binary.version>2.11</scala.binary.version>
-      </properties>
-      <activation>
-        <property>
-          <name>!scala-2.12</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <!-- make sure we don't have any _2.12 dependencies when building
-          for Scala 2.11 -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-enforcer-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>enforce-versions</id>
-                <goals>
-                  <goal>enforce</goal>
-                </goals>
-                <configuration>
-                  <rules>
-                    <bannedDependencies>
-                      <excludes>
-                        <exclude>*:*_2.12</exclude>
-                      </excludes>
-                    </bannedDependencies>
-                  </rules>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>scala-2.12</id>
-      <properties>
-        <scala.version>2.12.7</scala.version>
-        <scala.binary.version>2.12</scala.binary.version>
-      </properties>
-      <activation>
-        <property>
-          <name>scala-2.12</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <!-- make sure we don't have any _2.11 dependencies when building
-          for Scala 2.12 -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-enforcer-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>enforce-versions</id>
-                <goals>
-                  <goal>enforce</goal>
-                </goals>
-                <configuration>
-                  <rules>
-                    <bannedDependencies>
-                      <excludes>
-                        <exclude>*:*_2.11</exclude>
-                      </excludes>
-                    </bannedDependencies>
-                  </rules>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
fixed #273 

Add two modules for packaging two versions of scala packages at once.
The source code module is renamed to `pulsar-flink-connector-origin-${flink.binary.version}`, which gives users the freedom to choose a version without shade.