### PR TITLE
support use other docker image prefix

### DIFF
--- a/pulsar-flink-connector/pom.xml
+++ b/pulsar-flink-connector/pom.xml
@@ -190,12 +190,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>pulsar</artifactId>
-      <version>${testcontainers.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>

--- a/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarAuthTest.java
+++ b/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarAuthTest.java
@@ -20,6 +20,7 @@ import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions;
+import org.apache.flink.streaming.connectors.pulsar.testutils.PulsarContainer;
 import org.apache.flink.streaming.connectors.pulsar.testutils.TestUtils;
 import org.apache.flink.streaming.util.TestStreamEnvironment;
 import org.apache.flink.streaming.util.serialization.FlinkSchema;
@@ -38,7 +39,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.BindMode;
-import org.testcontainers.containers.PulsarContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
@@ -49,7 +49,7 @@ import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
-import static org.testcontainers.containers.PulsarContainer.BROKER_HTTP_PORT;
+import static org.apache.flink.streaming.connectors.pulsar.testutils.PulsarContainer.BROKER_HTTP_PORT;
 
 /**
  * pulsar auth tests.

--- a/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarTestBase.java
+++ b/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarTestBase.java
@@ -25,6 +25,7 @@ import org.apache.flink.connector.pulsar.source.util.PulsarAdminUtils;
 import org.apache.flink.metrics.jmx.JMXReporter;
 import org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions;
 import org.apache.flink.streaming.connectors.pulsar.internal.TopicRange;
+import org.apache.flink.streaming.connectors.pulsar.testutils.PulsarContainer;
 import org.apache.flink.streaming.util.TestStreamEnvironment;
 import org.apache.flink.util.TestLogger;
 
@@ -49,7 +50,6 @@ import org.apache.pulsar.shade.org.apache.commons.lang3.RandomStringUtils;
 import org.apache.pulsar.shade.org.apache.commons.lang3.StringUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.testcontainers.containers.PulsarContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
@@ -65,7 +65,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
-import static org.testcontainers.containers.PulsarContainer.BROKER_HTTP_PORT;
+import static org.apache.flink.streaming.connectors.pulsar.testutils.PulsarContainer.BROKER_HTTP_PORT;
 
 /**
  * Start / stop a Pulsar cluster.

--- a/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarTransactionalSinkTest.java
+++ b/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarTransactionalSinkTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.connectors.pulsar.table.PulsarSinkSemantic;
 import org.apache.flink.streaming.connectors.pulsar.testutils.FailingIdentityMapper;
 import org.apache.flink.streaming.connectors.pulsar.testutils.IntegerSource;
+import org.apache.flink.streaming.connectors.pulsar.testutils.PulsarContainer;
 import org.apache.flink.streaming.util.TestStreamEnvironment;
 import org.apache.flink.streaming.util.serialization.PulsarSerializationSchemaWrapper;
 import org.apache.flink.table.api.DataTypes;
@@ -43,7 +44,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.testcontainers.containers.BindMode;
-import org.testcontainers.containers.PulsarContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
@@ -58,7 +58,7 @@ import java.util.UUID;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.testcontainers.containers.PulsarContainer.BROKER_HTTP_PORT;
+import static org.apache.flink.streaming.connectors.pulsar.testutils.PulsarContainer.BROKER_HTTP_PORT;
 
 /**
  * Test for pulsar transactional sink that guarantee exactly-once semantic.

--- a/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/testutils/PulsarContainer.java
+++ b/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/testutils/PulsarContainer.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar.testutils;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
+import org.testcontainers.utility.DockerImageName;
+
+public class PulsarContainer extends GenericContainer<PulsarContainer> {
+    public static final int BROKER_PORT = 6650;
+    public static final int BROKER_HTTP_PORT = 8080;
+    public static final String METRICS_ENDPOINT = "/metrics";
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("apachepulsar/pulsar");
+    /**
+     * @deprecated
+     */
+    @Deprecated
+    private static final String DEFAULT_TAG = "2.7.1";
+    private boolean functionsWorkerEnabled;
+
+    /**
+     * @deprecated
+     */
+    @Deprecated
+    public PulsarContainer() {
+        this(DEFAULT_IMAGE_NAME.withTag("2.7.1"));
+    }
+
+    /**
+     * @deprecated
+     */
+    @Deprecated
+    public PulsarContainer(String pulsarVersion) {
+        this(DEFAULT_IMAGE_NAME.withTag(pulsarVersion));
+    }
+
+    public PulsarContainer(DockerImageName dockerImageName) {
+        super(dockerImageName);
+        this.functionsWorkerEnabled = false;
+        this.withExposedPorts(new Integer[]{6650, 8080});
+        this.withCommand(new String[]{"/pulsar/bin/pulsar", "standalone", "--no-functions-worker", "-nss"});
+        this.waitingFor(Wait.forHttp("/metrics").forStatusCode(200).forPort(8080));
+    }
+
+    protected void configure() {
+        super.configure();
+        if (this.functionsWorkerEnabled) {
+            this.withCommand(new String[]{"/pulsar/bin/pulsar", "standalone"});
+            this.waitingFor((new WaitAllStrategy()).withStrategy(this.waitStrategy).withStrategy(Wait.forLogMessage(".*Function worker service started.*", 1)));
+        }
+
+    }
+
+    public PulsarContainer withFunctionsWorker() {
+        this.functionsWorkerEnabled = true;
+        return this;
+    }
+
+    public String getPulsarBrokerUrl() {
+        return String.format("pulsar://%s:%s", this.getHost(), this.getMappedPort(6650));
+    }
+
+    public String getHttpServiceUrl() {
+        return String.format("http://%s:%s", this.getHost(), this.getMappedPort(8080));
+    }
+}


### PR DESCRIPTION
The current test docker image can only use `apachepulsar/pulsar`, if you want to support the use of sn-pulsar-image, you need to remove this restriction.