### PR TITLE
fix failOnDataLoss

### DIFF
--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarMetadataReader.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarMetadataReader.java
@@ -32,12 +32,14 @@ import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.shade.com.google.common.collect.Iterables;
 import org.apache.pulsar.shade.com.google.common.collect.Sets;
 
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -406,6 +408,24 @@ public class PulsarMetadataReader implements AutoCloseable {
             return this.admin.topics().getLastMessageId(topic);
         } catch (PulsarAdminException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    public boolean checkCursorAvailable(String topic, MessageIdImpl startMessageId) {
+        try {
+            PersistentTopicInternalStats stats = this.admin.topics().getInternalStats(topic);
+            long ledgerId = startMessageId.getLedgerId();
+            // Pulsar's ledger is out of order and cannot be compared by obtaining the last ledger.
+            // Therefore, it is a safer way to check whether the current ledger exists.
+            final Optional<PersistentTopicInternalStats.LedgerInfo> ledgerInfo = stats.ledgers.stream()
+                .filter(l -> l.ledgerId == ledgerId)
+                .findAny();
+            return !ledgerInfo.filter(info -> startMessageId.getEntryId() > info.entries).isPresent();
+        } catch (Exception e) {
+            String message = MessageFormat.format(
+                "valid Cursor fail topic [{0}], messageId [{2}]",
+                topic, startMessageId.toString());
+            throw new RuntimeException(message, e);
         }
     }
 


### PR DESCRIPTION
- fixed #300
- fixed #304 

The connector was able to deal with invalid cursor problems before, but it was damaged after upgrading to flink 1.11.  His logic is to check whether there is data loss before reading the data, and then decide whether to report an error according to **failOnDataLoss**.

In **ReaderThead**, an invalid cursor is checked when reading, and only the log is printed, but the cursor is still reset.  Of course it will fail and report an error.  I fixed the logic here. When an invalid cursor is encountered, failOnDataLoss decides whether to fail.  Continue to execute, the invalid cursor will be replaced with the next data obtained from the Reader.
