### PR TITLE
Fix  the cursor of start cannot be consumed when the cursor is larger than the latest cursor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,7 +532,8 @@ This parameter corresponds to the `FlinkPulsarSource` in StreamAPI, the Properti
 | flushoncheckpoint | true | Write a message to Pulsar topics. | sink |
 | failonwrite | false | When sink error occurs, continue to confirm the message. | sink |
 | polltimeoutms | 120000 | Set the timeout for waiting to get the next message, in unit of milliseconds. | source |
-| failondataloss | true | When data is lost, the operation fails. | source |
+| pulsar.reader.fail-on-data-loss | true | When data is lost, the operation fails. | source |
+| pulsar.reader.use-earliest-when-data-loss | false | When data is lost, use earliest reset offset. | source |
 | commitmaxretries | 3 | Set the maximum number of retries when an offset is set for Pulsar messages. | source |
 | send-delay-millisecond | 0 | delay millisecond message, just use **TableApi**, **StreamApi** use`PulsarSerializationSchema.setDeliverAtExtractor` | Sink |
 | scan.startup.mode | null | Set the earliest, latest, and the position where subscribers consume news,. It is a required parameter. | source |

--- a/doc/README_CN.md
+++ b/doc/README_CN.md
@@ -485,7 +485,8 @@ Pulsar Flink 连接器也支持 Key-Shared 订阅模式。可以通过配置参�
 | flushoncheckpoint                    | true          | 在 Flink snapshotState 时，向 Pulsar Topic 中写入消息。                      | sink         |
 | failonwrite                          | false         | Sink 出错时，继续确认消息。                                   | sink         |
 | polltimeoutms                        | 120000        | 等待获取下一条消息的超时时间，单位为毫秒。                        | source       |
-| failondataloss                       | true          | 数据丢失时，是否失败。                                       | source       |
+| pulsar.reader.fail-on-data-loss      | true          | 数据丢失时，是否失败。                                       | source       |
+| pulsar.reader.use-earliest-when-data-loss | false | 数据丢失时，使用earliest重置offset。 | source |
 | commitmaxretries                     | 3             | 向 Pulsar 消息偏移 offset 时，最大重试次数。                    | source       |
 | send-delay-millisecond               | 0             | 延迟消息发送(毫秒),仅限于TableApi,StreamApi请参考`PulsarSerializationSchema.setDeliverAtExtractor`           | Sink         |
 | scan.startup.mode                    | latest        | 消费消息的位置。支持 `earliest` 和 `latest`选项。                      | source       |

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
@@ -126,6 +126,8 @@ public class PulsarFetcher<T> {
     /** Failed or not when data loss. **/
     private boolean failOnDataLoss = true;
 
+    private boolean useEarliestWhenDataLoss;
+
     // ------------------------------------------------------------------------
     //  Metrics
     // ------------------------------------------------------------------------
@@ -204,6 +206,7 @@ public class PulsarFetcher<T> {
         this.clientConf = clientConf;
         this.readerConf = readerConf == null ? new HashMap<>() : readerConf;
         this.failOnDataLoss = SourceSinkUtils.getFailOnDataLossAndRemoveKey(this.readerConf);
+        this.useEarliestWhenDataLoss = SourceSinkUtils.getUseEarliestWhenDataLossAndRemoveKey(this.readerConf);
         this.pollTimeoutMs = pollTimeoutMs;
         this.commitMaxRetries = commitMaxRetries;
         this.deserializer = deserializer;
@@ -532,7 +535,8 @@ public class PulsarFetcher<T> {
                 deserializer,
                 pollTimeoutMs,
                 exceptionProxy,
-                failOnDataLoss);
+                failOnDataLoss,
+                useEarliestWhenDataLoss);
     }
 
     /**

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarOptions.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarOptions.java
@@ -61,6 +61,7 @@ public class PulsarOptions {
     public static final String KEY_DISABLED_METRICS = "key-disable-metrics";
     public static final String OLD_STATE_VERSION = "old-state-version";
     public static final String FAIL_ON_DATA_LOSS_OPTION_KEY = "failOnDataLoss";
+    public static final String USE_EARLIEST_WHEN_DATA_LOSS_OPTION_KEY = "use-earliest-when-data-loss";
     public static final String SEND_DELAY_MILLISECONDS = "send-delay-millisecond";
 
     public static final String INSTRUCTION_FOR_FAIL_ON_DATA_LOSS_FALSE =

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/ReaderThread.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/ReaderThread.java
@@ -146,13 +146,14 @@ public class ReaderThread<T> extends Thread {
             if (!messageIdRoughEquals(startMessageId, lastMessageId) && !reader.hasMessageAvailable()) {
                 MessageIdImpl startMsgIdImpl = (MessageIdImpl) startMessageId;
                 // startMessageId is bigger than lastMessageId
-                if (!metaDataReader.checkCursorAvailable(reader.getTopic(), startMsgIdImpl)) {
+                if (startMsgIdImpl.compareTo(lastMessageId) > 0) {
                     if (failOnDataLoss) {
                         log.error("the start message id is beyond the last commit message id, with topic:{}", this.topicRange);
                         throw new RuntimeException("start message id beyond the last commit");
                     } else {
-                        log.info("reset message to valid offset {}", startMessageId);
-                        metaDataReader.resetCursor(this.topicRange, startMessageId);
+                        log.info("reset message to valid offset {}", lastMessageId);
+                        reader.seek(lastMessageId);
+                        metaDataReader.resetCursor(this.topicRange, lastMessageId);
                     }
                 }
 

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/SourceSinkUtils.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/SourceSinkUtils.java
@@ -205,4 +205,11 @@ public class SourceSinkUtils {
         readerConf.remove(key);
         return value;
     }
+
+    public static boolean getUseEarliestWhenDataLossAndRemoveKey(Map<String, Object> readerConf) {
+        String failOnDataLossVal = readerConf.getOrDefault(PulsarOptions.USE_EARLIEST_WHEN_DATA_LOSS_OPTION_KEY, "false").toString();
+        final boolean value = Boolean.parseBoolean(failOnDataLossVal);
+        readerConf.remove(PulsarOptions.USE_EARLIEST_WHEN_DATA_LOSS_OPTION_KEY);
+        return value;
+    }
 }


### PR DESCRIPTION
fix #354 .


`if (!messageIdRoughEquals(startMessageId, lastMessageId) && !reader.hasMessageAvailable())` uses `startMsgIdImpl` to initialize the `reader`. This line of code already indicates that `startMsgIdImpl` is not available.

I used `metaDataReader#checkCursorAvailable` to check the existence of `startMsgIdImpl` in the Pulsar topic. It is meaningless. It is the same logic as above.


Now after the modification, I only need to consider two cases:
1. **startMsgIdImpl < lastMessageId**. This pulsar can be handled very well, without excessive attention.
2. **startMsgIdImpl > lastMessageId**. The pulsar broker cannot handle this situation from `2.6.0-2.7.1` . In response to this problem, I added reset the metaDataReader cursor and the reader cursor to lastMessageId.