### PR TITLE
fix lost first message

### DIFF
--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarFetcher.java
@@ -32,6 +32,7 @@ import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.shade.com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,6 +64,7 @@ public class PulsarFetcher<T> {
     protected final SourceContext<T> sourceContext;
 
     protected final Map<TopicRange, MessageId> seedTopicsWithInitialOffsets;
+    protected final Set<TopicRange> excludeStartMessageIds;
 
     /** The lock that guarantees that record emission and state updates are atomic,
      * from the view of taking a checkpoint. */
@@ -162,6 +164,7 @@ public class PulsarFetcher<T> {
         this(
                 sourceContext,
                 seedTopicsWithInitialOffsets,
+                Collections.emptySet(),
                 watermarkStrategy,
                 processingTimeProvider,
                 autoWatermarkInterval,
@@ -174,25 +177,27 @@ public class PulsarFetcher<T> {
                 deserializer,
                 metadataReader,
                 consumerMetricGroup,
-                useMetrics);
+                useMetrics
+        );
     }
 
     public PulsarFetcher(
-            SourceContext<T> sourceContext,
-            Map<TopicRange, MessageId> seedTopicsWithInitialOffsets,
-            SerializedValue<WatermarkStrategy<T>> watermarkStrategy,
-            ProcessingTimeService processingTimeProvider,
-            long autoWatermarkInterval,
-            ClassLoader userCodeClassLoader,
-            StreamingRuntimeContext runtimeContext,
-            ClientConfigurationData clientConf,
-            Map<String, Object> readerConf,
-            int pollTimeoutMs,
-            int commitMaxRetries,
-            PulsarDeserializationSchema<T> deserializer,
-            PulsarMetadataReader metadataReader,
-            MetricGroup consumerMetricGroup,
-            boolean useMetrics) throws Exception {
+        SourceContext<T> sourceContext,
+        Map<TopicRange, MessageId> seedTopicsWithInitialOffsets,
+        Set<TopicRange> excludeStartMessageIds,
+        SerializedValue<WatermarkStrategy<T>> watermarkStrategy,
+        ProcessingTimeService processingTimeProvider,
+        long autoWatermarkInterval,
+        ClassLoader userCodeClassLoader,
+        StreamingRuntimeContext runtimeContext,
+        ClientConfigurationData clientConf,
+        Map<String, Object> readerConf,
+        int pollTimeoutMs,
+        int commitMaxRetries,
+        PulsarDeserializationSchema<T> deserializer,
+        PulsarMetadataReader metadataReader,
+        MetricGroup consumerMetricGroup,
+        boolean useMetrics) throws Exception {
 
         this.sourceContext = sourceContext;
         this.watermarkOutput = new SourceContextWatermarkOutputAdapter<>(sourceContext);
@@ -200,6 +205,7 @@ public class PulsarFetcher<T> {
         this.useMetrics = useMetrics;
         this.consumerMetricGroup = checkNotNull(consumerMetricGroup);
         this.seedTopicsWithInitialOffsets = seedTopicsWithInitialOffsets;
+        this.excludeStartMessageIds = excludeStartMessageIds;
         this.checkpointLock = sourceContext.getCheckpointLock();
         this.userCodeClassLoader = userCodeClassLoader;
         this.runtimeContext = runtimeContext;
@@ -536,7 +542,8 @@ public class PulsarFetcher<T> {
                 pollTimeoutMs,
                 exceptionProxy,
                 failOnDataLoss,
-                useEarliestWhenDataLoss);
+                useEarliestWhenDataLoss,
+                excludeStartMessageIds.contains(state.getTopicRange()));
     }
 
     /**

--- a/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarITest.java
+++ b/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarITest.java
@@ -547,7 +547,7 @@ public class FlinkPulsarITest extends PulsarTestBaseWithFlink {
                 -20, -21, -22, 1, 2, 3, 10, 11, 12), Optional.empty());
 
         Map<String, Set<Integer>> expectedData = new HashMap<>();
-        expectedData.put(topic, new HashSet<>(Arrays.asList(2, 3, 10, 11, 12)));
+        expectedData.put(topic, new HashSet<>(Arrays.asList(1, 2, 3, 10, 11, 12)));
 
         Map<String, MessageId> offset = new HashMap<>();
         offset.put(topic, mids.get(3));
@@ -564,7 +564,7 @@ public class FlinkPulsarITest extends PulsarTestBaseWithFlink {
         DataStream stream = see.addSource(
                 new FlinkPulsarSource<>(serviceUrl, adminUrl, deserializationSchema, sourceProps)
                         .setStartFromSpecificOffsets(offset));
-        stream.flatMap(new CheckAllMessageExist(expectedData, 5, 1)).setParallelism(1);
+        stream.flatMap(new CheckAllMessageExist(expectedData, 6, 1)).setParallelism(1);
 
         TestUtils.tryExecute(see, "start from specific");
     }
@@ -583,7 +583,7 @@ public class FlinkPulsarITest extends PulsarTestBaseWithFlink {
         admin.topics().createSubscription(TopicName.get(topic).toString(), subName, mids.get(3));
 
         Map<String, Set<Integer>> expectedData = new HashMap<>();
-        expectedData.put(topic, new HashSet<>(Arrays.asList(2, 3, 10, 11, 12)));
+        expectedData.put(topic, new HashSet<>(Arrays.asList(1, 2, 3, 10, 11, 12)));
 
         StreamExecutionEnvironment see = StreamExecutionEnvironment.getExecutionEnvironment();
         see.setParallelism(1);
@@ -597,7 +597,7 @@ public class FlinkPulsarITest extends PulsarTestBaseWithFlink {
         DataStream stream =
                 see.addSource(new FlinkPulsarSource<>(serviceUrl, adminUrl, deserializationSchema, sourceProps)
                         .setStartFromSubscription(subName));
-        stream.flatMap(new CheckAllMessageExist(expectedData, 5, 1)).setParallelism(1);
+        stream.flatMap(new CheckAllMessageExist(expectedData, 6, 1)).setParallelism(1);
 
         TestUtils.tryExecute(see, "start from specific");
 

--- a/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSourceTest.java
+++ b/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSourceTest.java
@@ -616,7 +616,7 @@ public class FlinkPulsarSourceTest extends TestLogger {
                 long autoWatermarkInterval,
                 ClassLoader userCodeClassLoader,
                 StreamingRuntimeContext streamingRuntime,
-                boolean useMetrics) throws Exception {
+                boolean useMetrics, Set<TopicRange> inclusiveStartMessageIds) throws Exception {
             return new TestingFetcher<>(sourceContext, seedTopicsWithInitialOffsets, watermarkStrategy,
                     processingTimeProvider, autoWatermarkInterval);
         }
@@ -666,7 +666,7 @@ public class FlinkPulsarSourceTest extends TestLogger {
                 long autoWatermarkInterval,
                 ClassLoader userCodeClassLoader,
                 StreamingRuntimeContext streamingRuntime,
-                boolean useMetrics) throws Exception {
+                boolean useMetrics, Set<TopicRange> inclusiveStartMessageIds) throws Exception {
             return testFetcherSupplier.get();
         }
 


### PR DESCRIPTION
fixed #355, #362

- Remove the logic to skip the first message.
- Reader's startMessageId is Inclusive by default, and when recovering from checkpiont, the next message of startMessageId is consumed