### PR TITLE
[ENHANCEMENT] enhancement for setting up auth parameters

### DIFF
--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSinkBase.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSinkBase.java
@@ -214,6 +214,9 @@ abstract class FlinkPulsarSinkBase<T> extends TwoPhaseCommitSinkFunction<T, Flin
         if (this.clientConfigurationData.getServiceUrl() == null) {
             throw new IllegalArgumentException("ServiceUrl must be supplied in the client configuration");
         }
+
+        // setup auth parameters based on ClientConfigurationData and Properties
+        PulsarClientUtils.setupAuthIfNeed(clientConfigurationData, properties);
     }
 
     public FlinkPulsarSinkBase(

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSource.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSource.java
@@ -257,6 +257,9 @@ public class FlinkPulsarSource<T>
             throw new IllegalArgumentException("ServiceUrl must be supplied in the client configuration");
         }
         this.oldStateVersion = SourceSinkUtils.getOldStateVersion(caseInsensitiveParams, oldStateVersion);
+
+        // setup auth parameters based on ClientConfigurationData and Properties
+        PulsarClientUtils.setupAuthIfNeed(clientConfigurationData, properties);
     }
 
     public FlinkPulsarSource(

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarClientUtils.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarClientUtils.java
@@ -53,4 +53,19 @@ public class PulsarClientUtils {
 		return clientConf;
 	}
 
+	public static void setupAuthIfNeed(ClientConfigurationData conf, Properties properties) {
+	    if (!StringUtils.isBlank(conf.getAuthPluginClassName()) && !StringUtils.isBlank(conf.getAuthParams())) {
+	        // User has set up auth with ClientConfigurationData, which has the highest priority.
+        } else {
+	        if (properties != null &&
+                !StringUtils.isBlank(properties.getProperty(PulsarOptions.AUTH_PLUGIN_CLASSNAME_KEY)) &&
+                !StringUtils.isBlank(properties.getProperty(PulsarOptions.AUTH_PARAMS_KEY))) {
+	            // User only set up auth with Properties. Copy the properties to ClientConfigurationData.
+                conf.setAuthParams(properties.getProperty(PulsarOptions.AUTH_PARAMS_KEY));
+                conf.setAuthPluginClassName(properties.getProperty(PulsarOptions.AUTH_PLUGIN_CLASSNAME_KEY));
+            } else {
+	            // User does not enable authentication.
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Motivations
When I tried to create `FlinkPulsarSource` in the following way, 
```java
props.setProperty(PulsarOptions.AUTH_PLUGIN_CLASSNAME_KEY, "org.apache.pulsar.client.impl.auth.AuthenticationToken");
props.setProperty(PulsarOptions.AUTH_PARAMS_KEY, "token:abcdefghijklmn");

FlinkPulsarSource(adminUrl, clientConf, pulsarDeserializationSchema, props);
```

I found my flink job was failed and I can see some warnning logs in my broker like:
```
Failed to authenticate HTTP request: Authentication required
```

The reason for this problem is that only setting auth params in `Properties` will not take effect in the final initialization of `PulsarClient`.

## Modifications
Add some extra checking for this issue.