### PR TITLE
#386: Implemented passing of `CryptoKeyReader`.

### DIFF
--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSink.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSink.java
@@ -19,6 +19,7 @@ import org.apache.flink.streaming.connectors.pulsar.table.PulsarSinkSemantic;
 import org.apache.flink.streaming.util.serialization.PulsarSerializationSchema;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageRouter;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
@@ -26,9 +27,12 @@ import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -41,7 +45,114 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Slf4j
 public class FlinkPulsarSink<T> extends FlinkPulsarSinkBase<T> {
 
+    public static class Builder<T> {
+        private String adminUrl;
+        private String defaultTopicName;
+        private ClientConfigurationData clientConf;
+        private Properties properties;
+        private PulsarSerializationSchema<T>  serializationSchema;
+        private MessageRouter messageRouter = null;
+        private PulsarSinkSemantic semantic = PulsarSinkSemantic.AT_LEAST_ONCE;
+        private String serviceUrl;
+        private CryptoKeyReader cryptoKeyReader;
+        private final Set<String> encryptionKeys = new HashSet<>();
+
+        public Builder<T> withAdminUrl(final String adminUrl) {
+            this.adminUrl = adminUrl;
+            return this;
+        }
+
+        public Builder<T> withDefaultTopicName(final String defaultTopicName) {
+            this.defaultTopicName = defaultTopicName;
+            return this;
+        }
+
+        public Builder<T> withClientConf(final ClientConfigurationData clientConf) {
+            this.clientConf = clientConf;
+            return this;
+        }
+
+        public Builder<T> withProperties(final Properties properties) {
+            this.properties = properties;
+            return this;
+        }
+
+        public Builder<T> withPulsarSerializationSchema(final PulsarSerializationSchema<T> serializationSchema) {
+            this.serializationSchema = serializationSchema;
+            return this;
+        }
+
+        public Builder<T> withMessageRouter(final MessageRouter messageRouter) {
+            this.messageRouter = messageRouter;
+            return this;
+        }
+
+        public Builder<T> withSemantic(final PulsarSinkSemantic semantic) {
+            this.semantic = semantic;
+            return this;
+        }
+
+        public Builder<T> withServiceUrl(final String serviceUrl) {
+            this.serviceUrl = serviceUrl;
+            return this;
+        }
+
+        public Builder<T> withCryptoKeyReader(CryptoKeyReader cryptoKeyReader) {
+            this.cryptoKeyReader = cryptoKeyReader;
+            return this;
+        }
+
+        public Builder<T> withEncryptionKeys(String... encryptionKeys) {
+            this.encryptionKeys.addAll(Arrays.asList(encryptionKeys));
+            return this;
+        }
+
+        public FlinkPulsarSink<T>  build(){
+            if (adminUrl == null) {
+                throw new IllegalStateException("Admin URL must be set.");
+            }
+            if (serializationSchema == null) {
+                throw new IllegalStateException("Serialization schema must be set.");
+            }
+            if (semantic == null) {
+                throw new IllegalStateException("Semantic must be set.");
+            }
+            if (properties == null) {
+                throw new IllegalStateException("Properties must be set.");
+            }
+            if (serviceUrl != null && clientConf != null) {
+                throw new IllegalStateException("Set either client conf or service URL but not both.");
+            }
+            if (serviceUrl != null){
+                clientConf = PulsarClientUtils.newClientConf(checkNotNull(serviceUrl), properties);
+            }
+            if (clientConf == null){
+                throw new IllegalStateException("Client conf must be set.");
+            }
+            if ((cryptoKeyReader == null) != (encryptionKeys.isEmpty())){
+                throw new IllegalStateException("Set crypto key reader and encryption keys in conjunction.");
+            }
+            return new FlinkPulsarSink<>(this);
+        }
+
+    }
+
     private final PulsarSerializationSchema<T> serializationSchema;
+
+    public FlinkPulsarSink(final Builder<T> builder) {
+        super(
+            new FlinkPulsarSinkBase.Config<T>()
+                .withAdminUrl(builder.adminUrl)
+                .withDefaultTopicName(builder.defaultTopicName)
+                .withClientConf(builder.clientConf)
+                .withProperties(builder.properties)
+                .withSerializationSchema(builder.serializationSchema)
+                .withMessageRouter(builder.messageRouter)
+                .withSemantic(builder.semantic)
+                .withCryptoKeyReader(builder.cryptoKeyReader)
+                .withEncryptionKeys(builder.encryptionKeys));
+        this.serializationSchema = builder.serializationSchema;
+    }
 
     public FlinkPulsarSink(
             String adminUrl,
@@ -51,9 +162,14 @@ public class FlinkPulsarSink<T> extends FlinkPulsarSinkBase<T> {
             PulsarSerializationSchema serializationSchema,
             MessageRouter messageRouter,
             PulsarSinkSemantic semantic) {
-
-        super(adminUrl, defaultTopicName, clientConf, properties, serializationSchema, messageRouter, semantic);
-        this.serializationSchema = serializationSchema;
+        this(new Builder<T>()
+            .withAdminUrl(adminUrl)
+            .withDefaultTopicName(defaultTopicName.orElse(null))
+            .withClientConf(clientConf)
+            .withProperties(properties)
+            .withPulsarSerializationSchema(serializationSchema)
+            .withMessageRouter(messageRouter)
+            .withSemantic(semantic));
     }
 
     public FlinkPulsarSink(

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/ReaderThread.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/ReaderThread.java
@@ -18,6 +18,7 @@ import org.apache.flink.streaming.connectors.pulsar.util.MessageIdUtils;
 import org.apache.flink.streaming.util.serialization.PulsarDeserializationSchema;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -39,6 +40,80 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 public class ReaderThread<T> extends Thread {
 
+    public static class Builder<T> {
+        private PulsarFetcher<T> owner;
+        private PulsarTopicState<T> state;
+        private ClientConfigurationData clientConf;
+        private Map<String, Object> readerConf;
+        private PulsarDeserializationSchema<T> deserializer;
+        private int pollTimeoutMs;
+        private ExceptionProxy exceptionProxy;
+        private boolean failOnDataLoss;
+        private boolean useEarliestWhenDataLoss;
+        private boolean excludeMessageId;
+        private CryptoKeyReader cryptoKeyReader;
+
+        public Builder<T> withOwner(final PulsarFetcher<T> owner) {
+            this.owner = owner;
+            return this;
+        }
+
+        public Builder<T> withState(final PulsarTopicState<T> state) {
+            this.state = state;
+            return this;
+        }
+
+        public Builder<T> withClientConf(final ClientConfigurationData clientConf) {
+            this.clientConf = clientConf;
+            return this;
+        }
+
+        public Builder<T> withReaderConf(final Map<String, Object> readerConf) {
+            this.readerConf = readerConf;
+            return this;
+        }
+
+        public Builder<T> withDeserializer(final PulsarDeserializationSchema<T> deserializer) {
+            this.deserializer = deserializer;
+            return this;
+        }
+
+        public Builder<T> withPollTimeoutMs(final int pollTimeoutMs) {
+            this.pollTimeoutMs = pollTimeoutMs;
+            return this;
+        }
+
+        public Builder<T> withExceptionProxy(final ExceptionProxy exceptionProxy) {
+            this.exceptionProxy = exceptionProxy;
+            return this;
+        }
+
+        public Builder<T> withFailOnDataLoss(final boolean failOnDataLoss) {
+            this.failOnDataLoss = failOnDataLoss;
+            return this;
+        }
+
+        public Builder<T> withUseEarliestWhenDataLoss(final boolean useEarliestWhenDataLoss) {
+            this.useEarliestWhenDataLoss = useEarliestWhenDataLoss;
+            return this;
+        }
+
+        public Builder<T> withExcludeMessageId(final boolean excludeMessageId) {
+            this.excludeMessageId = excludeMessageId;
+            return this;
+        }
+
+        public Builder<T> withCryptoKeyReader(final CryptoKeyReader cryptoKeyReader) {
+            this.cryptoKeyReader = cryptoKeyReader;
+            return this;
+        }
+
+        public ReaderThread<T> build(){
+            return new ReaderThread<>(this);
+        }
+
+    }
+
     protected final PulsarFetcher<T> owner;
     protected final PulsarTopicState<T> state;
     protected final ClientConfigurationData clientConf;
@@ -58,6 +133,8 @@ public class ReaderThread<T> extends Thread {
 
     protected volatile Reader<T> reader = null;
 
+    private final CryptoKeyReader cryptoKeyReader;
+
     public ReaderThread(
             PulsarFetcher<T> owner,
             PulsarTopicState state,
@@ -76,6 +153,7 @@ public class ReaderThread<T> extends Thread {
 
         this.topicRange = state.getTopicRange();
         this.startMessageId = state.getOffset();
+        this.cryptoKeyReader = null;
     }
 
     public ReaderThread(
@@ -93,6 +171,22 @@ public class ReaderThread<T> extends Thread {
         this.failOnDataLoss = failOnDataLoss;
         this.useEarliestWhenDataLoss = useEarliestWhenDataLoss;
         this.excludeMessageId = excludeMessageId;
+    }
+
+    private ReaderThread(final Builder<T> builder){
+        this.owner = builder.owner;
+        this.state = builder.state;
+        this.clientConf = builder.clientConf;
+        this.readerConf = builder.readerConf;
+        this.deserializer = builder.deserializer;
+        this.pollTimeoutMs = builder.pollTimeoutMs;
+        this.exceptionProxy = builder.exceptionProxy;
+        this.topicRange =  state.getTopicRange();
+        this.startMessageId =  state.getOffset();
+        this.failOnDataLoss = builder.failOnDataLoss;
+        this.useEarliestWhenDataLoss = builder.useEarliestWhenDataLoss;
+        this.excludeMessageId = builder.excludeMessageId;
+        this.cryptoKeyReader = builder.cryptoKeyReader;
     }
 
     @Override
@@ -129,6 +223,9 @@ public class ReaderThread<T> extends Thread {
                 .topic(topicRange.getTopic())
                 .startMessageId(startMessageId)
                 .loadConf(readerConf);
+                if (cryptoKeyReader != null){
+                    readerBuilder.cryptoKeyReader(cryptoKeyReader);
+                }
         log.info("Create a reader at topic {} starting from message {} (inclusive) : config = {}",
                 topicRange, startMessageId, readerConf);
         if (!excludeMessageId){

--- a/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/SinkSrcRoundtripTest.java
+++ b/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/SinkSrcRoundtripTest.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar;
+
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.PrintSinkFunction;
+import org.apache.flink.streaming.util.serialization.PulsarSerializationSchemaWrapper;
+
+import org.apache.pulsar.client.api.CryptoKeyReader;
+import org.apache.pulsar.client.api.EncryptionKeyInfo;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.naming.TopicName;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions.TOPIC_SINGLE_OPTION_KEY;
+import static org.junit.Assert.assertTrue;
+
+public class SinkSrcRoundtripTest extends PulsarTestBase {
+
+    private static final String TOPIC_UNENCRYPTED = TopicName.get("persistent", "public", "default", "unencrypted-topic").toString();
+    private static final String TOPIC_ENCRYPTED = TopicName.get("persistent", "public", "default", "encrypted-topic").toString();
+
+    @Test(timeout = 60 * 1000)
+    public void testUnencryptedRoundtrip() throws Exception {
+        final Properties properties = new Properties();
+        final String topic = TOPIC_UNENCRYPTED;
+        properties.put(TOPIC_SINGLE_OPTION_KEY, topic);
+        final SimpleStringSchema schema = new SimpleStringSchema();
+        final PulsarSerializationSchemaWrapper<String> serializationSchema = new PulsarSerializationSchemaWrapper.Builder<>(schema)
+            .useSpecialMode(Schema.STRING)
+            .build();
+
+        final FlinkPulsarSink<String> sink = new FlinkPulsarSink.Builder<String>()
+            .withAdminUrl(getAdminUrl())
+            .withServiceUrl(getServiceUrl())
+            .withDefaultTopicName(topic)
+            .withProperties(properties)
+            .withPulsarSerializationSchema(serializationSchema)
+            .build();
+
+        final FlinkPulsarSource<String> src = new  FlinkPulsarSource.Builder<String>()
+            .withAdminUrl(getAdminUrl())
+            .withServiceUrl(getServiceUrl())
+            .withProperties(properties)
+            .withDeserializionSchema(schema)
+            .build()
+            .setStartFromEarliest();
+
+        roundtrip(sink, src);
+    }
+
+    private static class MyCryptoKeyReader implements CryptoKeyReader {
+
+        @Override
+        public EncryptionKeyInfo getPublicKey(String keyName, Map<String, String> metadata) {
+            EncryptionKeyInfo pub = new EncryptionKeyInfo();
+            pub.setKey(("" +
+                    "-----BEGIN RSA PUBLIC KEY-----\n" +
+                    "MIICCgKCAgEAyuz24j5TMVi9PthJpGYQ0sGJ+5uKPoVeoQQPvagOlIhKMCpjitmO\n" +
+                    "gZo5LvMFT0lACVzdxVkUpqEbRc9upopLDAhhHeHTauOxi7kH1iDO9kMKE5uy5QK5\n" +
+                    "JveG56drwIXrvQyz9NmEIkmSG/Ruisl9zDr+t3cdyLdwE4T0YU8JCj1Ex3Pnlr8c\n" +
+                    "iJoYV7VZoqJPJF3Le3PbXORxn5lXDnZcVkdDCDSLITAHegN5DU6/UJqIgwMQo0fQ\n" +
+                    "2dMiZ/VzqiPF1RHrBoM7/P2u507k2ZOS4jrIbKj9YdV4AibTDEYIhtSyIPkEJGDJ\n" +
+                    "GZINSxcfW9+exnq28B+NsJwwKNVoU60Phui6PcCOF4BXRYWMajJyLIrTNo8cFL5Z\n" +
+                    "Kid1+5BrYxCBdWDHJ4KiaT/y8y9q8ea+kUrUgp3VbsDstN1gU3vxzPcvaiTZc5xK\n" +
+                    "puEg4bbY5waN1y8JyfjwRUBk29CTXh3wQbd81DBjykfVL6OcbcVH8V0qLN7uhAPm\n" +
+                    "EGFyyqlwH93HsSCTHjJpkxBj2gO8n7/5YQJe9181tz+0xofc9kpDT1YTxdHxJevA\n" +
+                    "UsRfkrCGbwAdE2QhGmzwJSJCPdIanTEGRK8fr/6T0EM7TwrmHgLsCybpqdMil15u\n" +
+                    "8crgr8N7wTfm/iikdVs1sOtkjfG5WoNwm8XqS7g4CrVBFIVu/v8o++ECAwEAAQ==\n" +
+                    "-----END RSA PUBLIC KEY-----")
+                    .getBytes());
+            return pub;
+        }
+
+        @Override
+        public EncryptionKeyInfo getPrivateKey(String keyName, Map<String, String> metadata) {
+            EncryptionKeyInfo priv = new EncryptionKeyInfo();
+            priv.setKey(("" +
+                "-----BEGIN RSA PRIVATE KEY-----\n" +
+                "MIIJKAIBAAKCAgEAyuz24j5TMVi9PthJpGYQ0sGJ+5uKPoVeoQQPvagOlIhKMCpj\n" +
+                "itmOgZo5LvMFT0lACVzdxVkUpqEbRc9upopLDAhhHeHTauOxi7kH1iDO9kMKE5uy\n" +
+                "5QK5JveG56drwIXrvQyz9NmEIkmSG/Ruisl9zDr+t3cdyLdwE4T0YU8JCj1Ex3Pn\n" +
+                "lr8ciJoYV7VZoqJPJF3Le3PbXORxn5lXDnZcVkdDCDSLITAHegN5DU6/UJqIgwMQ\n" +
+                "o0fQ2dMiZ/VzqiPF1RHrBoM7/P2u507k2ZOS4jrIbKj9YdV4AibTDEYIhtSyIPkE\n" +
+                "JGDJGZINSxcfW9+exnq28B+NsJwwKNVoU60Phui6PcCOF4BXRYWMajJyLIrTNo8c\n" +
+                "FL5ZKid1+5BrYxCBdWDHJ4KiaT/y8y9q8ea+kUrUgp3VbsDstN1gU3vxzPcvaiTZ\n" +
+                "c5xKpuEg4bbY5waN1y8JyfjwRUBk29CTXh3wQbd81DBjykfVL6OcbcVH8V0qLN7u\n" +
+                "hAPmEGFyyqlwH93HsSCTHjJpkxBj2gO8n7/5YQJe9181tz+0xofc9kpDT1YTxdHx\n" +
+                "JevAUsRfkrCGbwAdE2QhGmzwJSJCPdIanTEGRK8fr/6T0EM7TwrmHgLsCybpqdMi\n" +
+                "l15u8crgr8N7wTfm/iikdVs1sOtkjfG5WoNwm8XqS7g4CrVBFIVu/v8o++ECAwEA\n" +
+                "AQKCAgBB5lCKypizxtC2bwEDXY4LE4Ue67Uqdp9zhOEjw0bw343QNIPdHKfV2OLH\n" +
+                "J27K/8vG/pyasUIultVHh4S0muaiQrpfPO4uoUEQUgeEd2Uevkiwc3jWPFsql2n9\n" +
+                "IvawMA2NeGmck2MAy4migG/BrIuo3mPH6uwGOeQwwpWmYEdcRudmKnLEFs5KYliT\n" +
+                "azZvxWwUME2bitVrRljL7r1B2hhEgKH5MS8ZmQJkkmomczNYFsdMXJtzmyftBU8A\n" +
+                "Gcr1LubZOhdsJwQ9NZkuTwWszur9gv+BoiOfOPbfJAKX0sqEFuC+KoA43CGSp0af\n" +
+                "4yNw758db86nDmgyOZa+PAfEXMhUf/3VFbnkca8w9vAP5w8b0W8GtCflcnC+vb1y\n" +
+                "qcToLbHaDnmhHLUdxHVj2XLTNxYFxmCmPhS+R8XRX4yPftni1skxjNOa6QbmHgVq\n" +
+                "7DgXcJJxJBk5+EIJrujk/eXzfU2zwUsYMt1dFLzwAvdc2fyoe8CCiBN+VUrhGoTF\n" +
+                "3IvYMzHYAdpxTdhKtQfShdI+tS3PLiEbzB3DxHH6H9X6Q0HZdLyGRufpqDW6DW1M\n" +
+                "zzCJIXRIcj8oZk36JsoH00RGOsCjdaeDOL13a3LCn0yBjuRPRVD0UlJA3EZT4/Ic\n" +
+                "QNvbgQe6zLbeIWWaYcstcAyjBCcW0mzEdlyUFIjU9LIVuJRhkQKCAQEA+D6p8KSb\n" +
+                "LhkwDGrt8X60QxattrRGVir5o/7lGCHkcnNBQUNXXy/8hrS41qsRhDHPSYHZFLwV\n" +
+                "66sIolkWhA9JEdZKfT/CsamHkfho8aitHh8YShdOog1OZQsunhFkaLzXO1mvDSUF\n" +
+                "W5ZLogUWy4oAduVwb4ANzNuW0pMGTYSzQHNJoHb91c/iu755av3VxeuxmomaKqBB\n" +
+                "h5TrNkHA+fUFvJqn/GZI0ZVyAqvIbyn7qN8y9rZcTa05L8oR2oyL7WVWF61ym03O\n" +
+                "V3f1gjSOU12acAGx5T6B6Bofb0v1xGgb4NMjacZcJ/lur9VmDZMlDt6XG6zWNalS\n" +
+                "/cB36JKQRgijfQKCAQEA0UPca7dG8cRryYpKYfHcCX3RIjp89XB83SWBpvNJr2+m\n" +
+                "BBHlsHPyU/NAVrh7rCL4S+TMsp8Dl/6sRjcon5R0a1gJfHPjmLTVx9tAD5Jbmn14\n" +
+                "zGemQDaGsV1DHxtL6B1a7qlKqq2QM4N6vzz18DvAkISs74iO9b+RwSFRLvkdmYQk\n" +
+                "e2CXDedNIPQlABV4nJlIQD6dAFBSdibf2xC8goXfxEtcRK6wf9/2SR0SVeOxnKDi\n" +
+                "KkeA9tqChW4Skk+WCHmDL8k375aYgViJcTmFD1cJHlj0lQGfk+gnxJnJwQJL7Cqg\n" +
+                "UYJxrX667sNnga8dcwFjqLF/hzAb75d+8cTXAE8fNQKCAQBOwdK4fgCdh3AvAF2t\n" +
+                "GD2oazGBnYATJl89IEkeduI7TUWOpwa5NEgxlHRv5qYQAp14/LEaWvG5avG6T/lM\n" +
+                "vGy6M/o98lSaeOaB8QWaZaFGxSa3mt1fnEka1YlcrLfmYsMGGVXoHa6td+lW5bZt\n" +
+                "rMKo9fHN7hpyu9gFxo9hWJBmCi15s0ak5udQGQX8Y7vGpxgZpz45983SbfSRqhrH\n" +
+                "Mm03gPl6ohjIJVmeb1GPswoccXOBwilWm3ZhKwKvC5f5IQVHTcfmbbDhHzXMsU/W\n" +
+                "MwQkNOVzjXk5YdBHRxoZzc3KbjH2BPCH3iK3tkRCWkSPix71sMflDms+BioEpzsO\n" +
+                "fP8hAoIBAQDRIYdr4pq0zP6HSHvzjDjBB4r0MQ1mX8d5Xp1GkkYmXGbGFHi+MfGQ\n" +
+                "Mj4vLGjz63LGrd5f+AgoYywZc9BWQo9iI3Y/eLWQi9BFzfgkV7jSGOibJk6AR72u\n" +
+                "DS0iLi5axtN0RZ1IGvJMeO43ph2GusBD7UPCkm+EarGoF7rBPdZ18BhhcHMlQu3S\n" +
+                "rAs6HTsPDSSmh6xxftQaHdmDXSN3MYEh88o/HXFoKhNAmBwV19pNVH8Rj6nziQX9\n" +
+                "gLZwn7apu33+SJJtDsxUH34juD8gyHNlb7LmItwufUkY8jQtfjUPzL2xF7Kxl0AL\n" +
+                "kx6i/LVqlI3bLZ/sI4kXlQgZaAUR2wCtAoIBAG/EIzsdMmM5ym7FX1KuQX1FsEFN\n" +
+                "avzwjnpzR4dp3m8/IS2yTKxyb83zHauox+1m6PnEU8yihvJkAt4JJSk9aC4PeZt+\n" +
+                "b3MV6lHGgN4Q5EjGGOwEDh4yfyCW6eJACyIc7eyySXA0W3dvnZChgp6zav/3rZr7\n" +
+                "mETaPxWH9AYy2U9KLzSYNPrYVnPz97vjwFLRAsWQCRhYm/4mU/53GCqsxW7lW1f1\n" +
+                "e6NqFGHNw6ubOl4p3lNX53mYp4Fn7YJNumAftEBd8r9LS7HYL7XUzYrrgt57WVMt\n" +
+                "8svUxDU98U1YCSNWAupd4se08tdprO5czULIEjCqS1we4J07hICeWEaxfss=\n" +
+                "-----END RSA PRIVATE KEY-----").getBytes());
+            return priv;
+        }
+    }
+
+    @Test(timeout = 60 * 1000)
+    public void testEncryptedRoundtrip() throws Exception {
+
+        final Properties properties = new Properties();
+        final String topic = TOPIC_ENCRYPTED;
+        properties.put(TOPIC_SINGLE_OPTION_KEY, topic);
+        final SimpleStringSchema schema = new SimpleStringSchema();
+        final PulsarSerializationSchemaWrapper<String> serializationSchema = new PulsarSerializationSchemaWrapper.Builder<>(schema)
+            .useSpecialMode(Schema.STRING)
+            .build();
+
+        CryptoKeyReader cryptoKeyReader = new MyCryptoKeyReader();
+
+        final FlinkPulsarSink<String> sink = new FlinkPulsarSink.Builder<String>()
+            .withAdminUrl(getAdminUrl())
+            .withServiceUrl(getServiceUrl())
+            .withDefaultTopicName(topic)
+            .withProperties(properties)
+            .withPulsarSerializationSchema(serializationSchema)
+            .withCryptoKeyReader(cryptoKeyReader)
+            .withEncryptionKeys("key1", "key2")
+            .build();
+
+        final FlinkPulsarSource<String> src = new  FlinkPulsarSource.Builder<String>()
+            .withAdminUrl(getAdminUrl())
+            .withServiceUrl(getServiceUrl())
+            .withProperties(properties)
+            .withDeserializionSchema(schema)
+            .withCryptoKeyReader(cryptoKeyReader)
+            .build()
+            .setStartFromEarliest();
+
+        roundtrip(sink, src);
+    }
+
+    private void roundtrip(FlinkPulsarSink<String> sink, FlinkPulsarSource<String> src) throws Exception {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+        ArrayList<String> input = new ArrayList<>();
+        input.add("Hello");
+        input.add("world");
+        input.add("!");
+
+        final DataStream<String> out = env
+            .fromCollection(input);
+        out.addSink(sink);
+
+        final DataStream<String> in = env.addSource(src);
+        in.addSink(new PrintSinkFunction<>());
+        final Iterator<String> iterator = in.executeAndCollect("Roundtrip Job");
+
+        final List<String> results = new LinkedList<>();
+        while (iterator.hasNext()){
+            final String item = iterator.next();
+            results.add(item);
+            assertTrue(input.containsAll(results));
+            if (results.size() >= input.size()){
+                // Happy!
+                break;
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Implemented passing a `CryptoKeyReader` (and encryption keys) to `FlinkPulsarSource` and `FlinkPulsarSink`, as requested [here](https://github.com/streamnative/pulsar-flink/issues/386).

Used builder pattern for easy extensibility without breaking or excessively overloading public c'tors.

Added test. (Maybe it can be moved to one of the other tests to avoid overhead.)