### PR TITLE
Fix parse map type for protobuf DynamicMessage

### DIFF
--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/SimpleSchemaTranslator.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/SimpleSchemaTranslator.java
@@ -336,7 +336,7 @@ public class SimpleSchemaTranslator extends SchemaTranslator {
         }
     }
 
-    private static DataType proto2SqlType(Descriptors.Descriptor descriptor) throws
+    public static DataType proto2SqlType(Descriptors.Descriptor descriptor) throws
             IncompatibleSchemaException {
         List<DataTypes.Field> fields = new ArrayList<>();
         List<Descriptors.FieldDescriptor> protoFields = descriptor.getFields();

--- a/pulsar-flink-connector/src/test/java/org/apache/flink/formats/protobufnative/PulsarProtobufNativeRowDataDeserializationSchemaTest.java
+++ b/pulsar-flink-connector/src/test/java/org/apache/flink/formats/protobufnative/PulsarProtobufNativeRowDataDeserializationSchemaTest.java
@@ -14,35 +14,61 @@
 
 package org.apache.flink.formats.protobufnative;
 
-import org.apache.flink.formats.protobuf.PbRowTypeInformation;
-import org.apache.flink.streaming.connectors.pulsar.SchemaData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 
+import com.google.protobuf.Descriptors;
+import org.apache.pulsar.client.impl.schema.ProtobufNativeSchemaUtils;
+import org.junit.Before;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.apache.flink.streaming.connectors.pulsar.internal.SimpleSchemaTranslator.proto2SqlType;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
 public class PulsarProtobufNativeRowDataDeserializationSchemaTest {
 
+    public byte[] protobufData;
+
+    public Descriptors.Descriptor descriptor;
+
+    @Before
+    public void setUp() throws Exception {
+        String schema =
+                "{\"fileDescriptorSet\":\"CtcGCg5wYjNfdGVzdC5wcm90bxInb3JnLmFwYWNoZS5mbGluay5mb3JtYXRzLnByb3RvYnVmLnByb3RvIuIFCgdQYjNUZXN0EgkKAWEYASABKAUSCQoBYhgCIAEoAxIJCgFjGAMgASgJEgkKAWQYBCABKAISCQoBZRgFIAEoARJCCgFmGAYgASgOMjcub3JnLmFwYWNoZS5mbGluay5mb3JtYXRzLnByb3RvYnVmLnByb3RvLlBiM1Rlc3QuQ29ycHVzEkwKAWcYByABKAsyQS5vcmcuYXBhY2hlLmZsaW5rLmZvcm1hdHMucHJvdG9idWYucHJvdG8uUGIzVGVzdC5Jbm5lck1lc3NhZ2VUZXN0EkwKAWgYCCADKAsyQS5vcmcuYXBhY2hlLmZsaW5rLmZvcm1hdHMucHJvdG9idWYucHJvdG8uUGIzVGVzdC5Jbm5lck1lc3NhZ2VUZXN0EgkKAWkYCSABKAwSSAoEbWFwMRgKIAMoCzI6Lm9yZy5hcGFjaGUuZmxpbmsuZm9ybWF0cy5wcm90b2J1Zi5wcm90by5QYjNUZXN0Lk1hcDFFbnRyeRJICgRtYXAyGAsgAygLMjoub3JnLmFwYWNoZS5mbGluay5mb3JtYXRzLnByb3RvYnVmLnByb3RvLlBiM1Rlc3QuTWFwMkVudHJ5GisKCU1hcDFFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBGm4KCU1hcDJFbnRyeRILCgNrZXkYASABKAkSUAoFdmFsdWUYAiABKAsyQS5vcmcuYXBhY2hlLmZsaW5rLmZvcm1hdHMucHJvdG9idWYucHJvdG8uUGIzVGVzdC5Jbm5lck1lc3NhZ2VUZXN0OgI4ARooChBJbm5lck1lc3NhZ2VUZXN0EgkKAWEYASABKAUSCQoBYhgCIAEoAyJaCgZDb3JwdXMSDQoJVU5JVkVSU0FMEAASBwoDV0VCEAESCgoGSU1BR0VTEAISCQoFTE9DQUwQAxIICgRORVdTEAQSDAoIUFJPRFVDVFMQBRIJCgVWSURFTxAHQi8KK29yZy5hcGFjaGUuZmxpbmsuZm9ybWF0cy5wcm90b2J1Zi50ZXN0cHJvdG9QAWIGcHJvdG8z\",\"rootMessageTypeName\":\"org.apache.flink.formats.protobuf.proto.Pb3Test\",\"rootFileDescriptorName\":\"pb3_test.proto\"}";
+        descriptor = ProtobufNativeSchemaUtils.deserialize(schema.getBytes(StandardCharsets.UTF_8));
+        protobufData = Base64.getDecoder().decode(
+                "CGMQARoEdGVzdCXNzIw/KcP1KFyPwvE/MAE6BAhjEGNCBAhjEGNCBAhjEGNKATFSCgoDMTExEgMyMjJSDAoEMTExMhIEMjIyM1oLCgMxMTESBAhjEGNaDAoEMTExMhIECGMQYw==");
+    }
+
     @Test
     public void deserialize() throws Exception {
-        RowType rowType = PbRowTypeInformation.generateRowType(SchemaData.descriptor);
-        PulsarProtobufNativeRowDataDeserializationSchema deserializationSchema = new PulsarProtobufNativeRowDataDeserializationSchema(() -> SchemaData.descriptor, rowType);
+        RowType rowType = (RowType) proto2SqlType(descriptor).getLogicalType();
+        PulsarProtobufNativeRowDataDeserializationSchema deserializationSchema =
+                new PulsarProtobufNativeRowDataDeserializationSchema(() -> descriptor, rowType);
         deserializationSchema.open(null);
 
-        final RowData rowData = deserializationSchema.deserialize(SchemaData.protobufData);
+        final RowData rowData = deserializationSchema.deserialize(protobufData);
         RowData newRowData = rowData;
-        assertEquals(9, newRowData.getArity());
-        assertEquals(1, newRowData.getInt(0));
-        assertEquals(2L, newRowData.getLong(1));
-        assertFalse((boolean) newRowData.getBoolean(2));
-        assertEquals(Float.valueOf(0.1f), Float.valueOf(newRowData.getFloat(3)));
-        assertEquals(Double.valueOf(0.01d), Double.valueOf(newRowData.getDouble(4)));
-        assertEquals("haha", newRowData.getString(5).toString());
-        assertEquals(1, (newRowData.getBinary(6))[0]);
-        assertEquals("IMAGES", newRowData.getString(7).toString());
-        assertEquals(1, newRowData.getInt(8));
+        assertEquals(11, newRowData.getArity());
+        assertEquals(99, newRowData.getInt(0));
+        assertEquals(1L, newRowData.getLong(1));
+        assertEquals("test", newRowData.getString(2).toString());
+        assertEquals(Float.valueOf(1.1f), Float.valueOf(newRowData.getFloat(3)));
+        assertEquals(Double.valueOf(1.11d), Double.valueOf(newRowData.getDouble(4)));
+        assertEquals("WEB", newRowData.getString(5).toString());
+        assertEquals("+I(99,99)", newRowData.getRow(6, 2).toString());
+        assertEquals(2, newRowData.getArray(7).size());
+        assertEquals(99, newRowData.getArray(7).getRow(0, 1).getInt(0));
+        assertEquals(99, newRowData.getArray(7).getRow(1, 1).getInt(0));
+        assertEquals(49, newRowData.getBinary(8)[0]);
+        assertEquals(2, newRowData.getMap(9).size());
+        assertEquals("1112", newRowData.getMap(9).keyArray().getString(0).toString());
+        assertEquals("2223", newRowData.getMap(9).valueArray().getString(0).toString());
+        assertEquals(2, newRowData.getMap(10).size());
+        assertEquals("1112", newRowData.getMap(10).keyArray().getString(0).toString());
+        assertEquals("+I(99,99)", newRowData.getMap(10).valueArray().getRow(0, 2).toString());
     }
 }


### PR DESCRIPTION
fixed #393.

Since the Protobuf message is decoded into `DynamicMessage`, the java `Map` type in the message body will be mapped to the `List<DynamicMessage>` structure. Therefore, in the method of converting to `Map`, the processing logic of `Collection<DynamicMessage>` is added.