### PR TITLE
fix the pulsar schema cannot exclude the key fields.

### DIFF
--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarOptions.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarOptions.java
@@ -90,7 +90,6 @@ public class PulsarOptions {
             PUBLISH_TIME_NAME,
             EVENT_TIME_NAME);
 
-    public static final String DEFAULT_PARTITIONS = "table-default-partitions";
     public static final String AUTH_PARAMS_KEY = "auth-params";
     public static final String AUTH_PLUGIN_CLASSNAME_KEY = "auth-plugin-classname";
 }

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/SchemaUtils.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/SchemaUtils.java
@@ -14,6 +14,7 @@
 
 package org.apache.flink.streaming.connectors.pulsar.internal;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.formats.protobuf.PbFormatOptions;
 import org.apache.flink.streaming.connectors.pulsar.config.RecordSchemaType;
@@ -40,7 +41,6 @@ import org.apache.pulsar.shade.org.apache.commons.lang3.StringUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Map;
 
 import static org.apache.avro.Schema.Type.RECORD;
 import static org.apache.pulsar.shade.com.google.common.base.Preconditions.checkNotNull;
@@ -217,7 +217,7 @@ public class SchemaUtils {
     }
 
     public static SchemaInfo tableSchemaToSchemaInfo(String format, DataType dataType,
-                                                     Map<String, String> options)
+                                                     Configuration configuration)
             throws IncompatibleSchemaException {
         switch (StringUtils.lowerCase(format)) {
             case "json":
@@ -225,7 +225,7 @@ public class SchemaUtils {
             case "avro":
                 return getSchemaInfo(SchemaType.AVRO, dataType);
             case "protobuf":
-                final String messageClassName = options.get(PbFormatOptions.MESSAGE_CLASS_NAME.key());
+                final String messageClassName = configuration.get(PbFormatOptions.MESSAGE_CLASS_NAME);
                 return getProtobufSchemaInfo(messageClassName, SchemaUtils.class.getClassLoader());
             case "atomic":
                 org.apache.pulsar.client.api.Schema pulsarSchema =

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/table/PulsarDynamicTableSink.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/table/PulsarDynamicTableSink.java
@@ -209,7 +209,7 @@ public class PulsarDynamicTableSink implements DynamicTableSink, SupportsWriting
                 hasMetadata,
                 metadataPositions,
                 upsertMode,
-                physicalDataType,
+                DataTypeUtils.projectRow(physicalDataType, valueProjection),
                 formatType,
                 delayMilliseconds);
     }

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/table/PulsarTableOptions.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/table/PulsarTableOptions.java
@@ -54,7 +54,7 @@ import static org.apache.flink.streaming.connectors.pulsar.internal.PulsarOption
 import static org.apache.flink.streaming.connectors.pulsar.table.PulsarSinkSemantic.AT_LEAST_ONCE;
 import static org.apache.flink.streaming.connectors.pulsar.table.PulsarSinkSemantic.EXACTLY_ONCE;
 import static org.apache.flink.streaming.connectors.pulsar.table.PulsarSinkSemantic.NONE;
-import static org.apache.flink.table.factories.FactoryUtil.FORMAT_SUFFIX;
+import static org.apache.flink.table.factories.FactoryUtil.FORMAT;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
 
 /**
@@ -68,16 +68,17 @@ public class PulsarTableOptions {
     // --------------------------------------------------------------------------------------------
 
     public static final ConfigOption<String> KEY_FORMAT = ConfigOptions
-            .key("key" + FORMAT_SUFFIX)
+            .key("key." + FORMAT.key())
             .stringType()
             .noDefaultValue()
             .withDescription("Defines the format identifier for encoding key data. "
                     + "The identifier is used to discover a suitable format factory.");
 
     public static final ConfigOption<String> VALUE_FORMAT = ConfigOptions
-            .key("value" + FORMAT_SUFFIX)
+            .key("value." + FORMAT.key())
             .stringType()
             .noDefaultValue()
+            .withFallbackKeys(FORMAT.key())
             .withDescription("Defines the format identifier for encoding value data. "
                     + "The identifier is used to discover a suitable format factory.");
 

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/table/catalog/pulsar/PulsarCatalog.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/table/catalog/pulsar/PulsarCatalog.java
@@ -14,12 +14,12 @@
 
 package org.apache.flink.table.catalog.pulsar;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.connectors.pulsar.internal.IncompatibleSchemaException;
 import org.apache.flink.streaming.connectors.pulsar.internal.PulsarCatalogSupport;
 import org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions;
 import org.apache.flink.streaming.connectors.pulsar.internal.SimpleSchemaTranslator;
 import org.apache.flink.streaming.connectors.pulsar.table.PulsarDynamicTableFactory;
-import org.apache.flink.streaming.connectors.pulsar.table.PulsarTableOptions;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogDatabase;
 import org.apache.flink.table.catalog.CatalogDatabaseImpl;
@@ -39,7 +39,6 @@ import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
 import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
-import org.apache.flink.table.descriptors.FormatDescriptorValidator;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.factories.Factory;
 
@@ -54,7 +53,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.flink.streaming.connectors.pulsar.table.PulsarTableOptions.PROPERTIES_PREFIX;
-import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR;
+import static org.apache.flink.table.catalog.pulsar.factories.PulsarCatalogFactoryOptions.DEFAULT_PARTITIONS;
 
 /**
  * Expose a Pulsar instance as a database catalog.
@@ -64,16 +63,16 @@ public class PulsarCatalog extends GenericInMemoryCatalog {
 
     private String adminUrl;
 
-    private Map<String, String> properties;
+    private Configuration configuration;
 
     private PulsarCatalogSupport catalogSupport;
 
     public static final String DEFAULT_DB = "public/default";
 
-    public PulsarCatalog(String adminUrl, String catalogName, Map<String, String> props, String defaultDatabase) {
+    public PulsarCatalog(String adminUrl, String catalogName, Configuration configuration, String defaultDatabase) {
         super(catalogName, defaultDatabase);
         this.adminUrl = adminUrl;
-        this.properties = new HashMap<>(props);
+        this.configuration = configuration;
         log.info("Created Pulsar Catalog {}", catalogName);
     }
 
@@ -87,9 +86,11 @@ public class PulsarCatalog extends GenericInMemoryCatalog {
         if (catalogSupport == null) {
             try {
                 final ClientConfigurationData clientConf = new ClientConfigurationData();
-                clientConf.setAuthParams(properties.get(PROPERTIES_PREFIX + PulsarOptions.AUTH_PARAMS_KEY));
+                clientConf.setAuthParams(
+                        configuration.getString(PROPERTIES_PREFIX + PulsarOptions.AUTH_PARAMS_KEY, null));
                 clientConf.setAuthPluginClassName(
-                        properties.get(PROPERTIES_PREFIX + PulsarOptions.AUTH_PLUGIN_CLASSNAME_KEY));
+                        configuration.getString(PROPERTIES_PREFIX + PulsarOptions.AUTH_PLUGIN_CLASSNAME_KEY, null));
+
                 catalogSupport = new PulsarCatalogSupport(adminUrl, clientConf, "",
                         new HashMap<>(), -1, -1, new SimpleSchemaTranslator(false));
             } catch (PulsarClientException e) {
@@ -165,7 +166,7 @@ public class PulsarCatalog extends GenericInMemoryCatalog {
             return super.getTable(tablePath);
         }
         try {
-            return catalogSupport.getTableSchema(tablePath, properties);
+            return catalogSupport.getTableSchema(tablePath, configuration);
         } catch (PulsarAdminException.NotFoundException e) {
             throw new TableNotExistException(getName(), tablePath, e);
         } catch (PulsarAdminException | IncompatibleSchemaException e) {
@@ -193,8 +194,8 @@ public class PulsarCatalog extends GenericInMemoryCatalog {
         if (tablePath.getObjectName().startsWith("_tmp_table_")) {
             super.createTable(tablePath, table, ignoreIfExists);
         }
-        final String key = CONNECTOR + "." + PulsarOptions.DEFAULT_PARTITIONS;
-        int defaultNumPartitions = Integer.parseInt(properties.getOrDefault(key, "5"));
+
+        int defaultNumPartitions = configuration.getInteger(DEFAULT_PARTITIONS);
         String databaseName = tablePath.getDatabaseName();
         Boolean databaseExists;
         try {
@@ -209,7 +210,7 @@ public class PulsarCatalog extends GenericInMemoryCatalog {
 
         try {
             catalogSupport.createTopic(tablePath, defaultNumPartitions, table);
-            catalogSupport.putSchema(tablePath, table, getFormat());
+            catalogSupport.putSchema(tablePath, table, configuration);
         } catch (PulsarAdminException e) {
             if (e.getStatusCode() == 409) {
                 throw new TableAlreadyExistException(getName(), tablePath, e);
@@ -219,11 +220,6 @@ public class PulsarCatalog extends GenericInMemoryCatalog {
         } catch (IncompatibleSchemaException e) {
             throw new CatalogException("Failed to translate Flink type to Pulsar", e);
         }
-    }
-
-    private String getFormat() {
-        return Optional.ofNullable(properties.get(FormatDescriptorValidator.FORMAT))
-                .orElseGet(() -> properties.get(PulsarTableOptions.VALUE_FORMAT.key()));
     }
 
     // ------------------------------------------------------------------------

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/table/catalog/pulsar/factories/PulsarCatalogFactory.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/table/catalog/pulsar/factories/PulsarCatalogFactory.java
@@ -15,6 +15,7 @@
 package org.apache.flink.table.catalog.pulsar.factories;
 
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.pulsar.PulsarCatalog;
 import org.apache.flink.table.factories.CatalogFactory;
@@ -28,6 +29,7 @@ import static org.apache.flink.streaming.connectors.pulsar.table.PulsarTableOpti
 import static org.apache.flink.streaming.connectors.pulsar.table.PulsarTableOptions.KEY_FIELDS_PREFIX;
 import static org.apache.flink.streaming.connectors.pulsar.table.PulsarTableOptions.KEY_FORMAT;
 import static org.apache.flink.streaming.connectors.pulsar.table.PulsarTableOptions.PROPERTIES;
+import static org.apache.flink.streaming.connectors.pulsar.table.PulsarTableOptions.PROPERTIES_PREFIX;
 import static org.apache.flink.streaming.connectors.pulsar.table.PulsarTableOptions.SCAN_STARTUP_MODE;
 import static org.apache.flink.streaming.connectors.pulsar.table.PulsarTableOptions.SERVICE_URL;
 import static org.apache.flink.streaming.connectors.pulsar.table.PulsarTableOptions.SINK_SEMANTIC;
@@ -53,11 +55,11 @@ public class PulsarCatalogFactory implements CatalogFactory {
     public Catalog createCatalog(Context context) {
         final FactoryUtil.CatalogFactoryHelper helper =
                 FactoryUtil.createCatalogFactoryHelper(this, context);
-        helper.validate();
+        helper.validateExcept(PROPERTIES_PREFIX);
         return new PulsarCatalog(
                 helper.getOptions().get(ADMIN_URL),
                 context.getName(),
-                context.getOptions(),
+                (Configuration) helper.getOptions(),
                 helper.getOptions().get(DEFAULT_DATABASE));
     }
 

--- a/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarCatalogSupportTest.java
+++ b/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarCatalogSupportTest.java
@@ -1,0 +1,71 @@
+package org.apache.flink.streaming.connectors.pulsar.internal;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.connectors.pulsar.table.PulsarTableOptions;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedSchema;
+
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/**
+ * unit test for PulsarCatalogSupport.
+ */
+public class PulsarCatalogSupportTest {
+
+    @Test
+    public void putSchema() throws PulsarAdminException {
+        final CatalogBaseTable catalogBaseTable = mock(CatalogBaseTable.class);
+        final ResolvedSchema schema2 = ResolvedSchema.of(
+                Column.physical("physical_1", DataTypes.STRING()),
+                Column.physical("physical_2", DataTypes.INT()),
+                Column.metadata("eventTime", DataTypes.TIMESTAMP(3), "eventTime", false),
+                Column.metadata("properties", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING()), "properties",
+                        false),
+                Column.metadata("topic", DataTypes.STRING(), "topic", true),
+                Column.metadata("sequenceId", DataTypes.BIGINT(), "sequenceId", true),
+                Column.physical("key", DataTypes.STRING()),
+                Column.physical("physical_3", DataTypes.BOOLEAN())
+        );
+        when(catalogBaseTable.getSchema()).thenReturn(TableSchema.fromResolvedSchema(schema2));
+        when(catalogBaseTable.getUnresolvedSchema()).thenReturn(
+                Schema.newBuilder().fromResolvedSchema(schema2).build());
+        final Configuration configuration = getCatalogConfig();
+
+        PulsarMetadataReader metadataReader = verify(mock(PulsarMetadataReader.class), data -> {
+            final SchemaInfo schemaInfo = data.getTarget().getInvocation().getArgument(1, SchemaInfo.class);
+            final org.apache.avro.Schema schema =
+                    new org.apache.avro.Schema.Parser().parse(new String(schemaInfo.getSchema()));
+
+            Assert.assertEquals(schema.getFields().size(), 3);
+            Assert.assertEquals(schema.getFields().get(0).name(), "physical_1");
+            Assert.assertEquals(schema.getFields().get(1).name(), "physical_2");
+            Assert.assertEquals(schema.getFields().get(2).name(), "physical_3");
+        });
+        final PulsarCatalogSupport catalogSupport =
+                new PulsarCatalogSupport(metadataReader, new SimpleSchemaTranslator());
+        catalogSupport.putSchema(ObjectPath.fromString("public/default.test"), catalogBaseTable, configuration);
+    }
+
+    private Configuration getCatalogConfig() {
+        final Configuration configuration = new Configuration();
+        configuration.set(PulsarTableOptions.VALUE_FORMAT, "avro");
+        configuration.set(PulsarTableOptions.KEY_FORMAT, "string");
+        configuration.set(PulsarTableOptions.KEY_FIELDS, Collections.singletonList("key"));
+        configuration.set(PulsarTableOptions.VALUE_FIELDS_INCLUDE, PulsarTableOptions.ValueFieldsStrategy.EXCEPT_KEY);
+        return configuration;
+    }
+}

--- a/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarCatalogSupportTest.java
+++ b/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarCatalogSupportTest.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.streaming.connectors.pulsar.internal;
 
 import org.apache.flink.configuration.Configuration;


### PR DESCRIPTION
fixed #400 

- fix pulsar schema cannot exclude the key fields on table.
- fix pulsar schema cannot exclude the key fields on catalog.
- add test for `PulsarCatalogSupport`
- change field `Map<String, String> properties` to `Configuration configuration` on `PulsarCatalog`.
- try use `create catalog` sql prepare the test environment  `CatalogITest#testTableSchema`.
   -  flink will remove the initialization yaml config of sql-client in 1.14, and flink 1.13 have deprecated `sql-client-defaults.yaml`