### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ We change our project [version definition](doc/connector-version-definition.md),
 | 1.10.x        | 2.5.x                            | [`release-1.10`](https://github.com/streamnative/pulsar-flink/tree/release-1.10) |
 | 1.11.x        | 2.6.x                            | [`release-1.11`](https://github.com/streamnative/pulsar-flink/tree/release-1.11) |
 | 1.12.x        | 2.7.x                            | [`release-1.12`](https://github.com/streamnative/pulsar-flink/tree/release-1.12) |
+| 1.13.x        | 2.8.x                            | [`release-1.13`](https://github.com/streamnative/pulsar-flink/tree/release-1.13) |
 
 > **Note**  
 > Since Flink's API changed greatly through different versions, we mainly work on new features for the latest released flink version and fix bugs for old release.

--- a/doc/README_CN.md
+++ b/doc/README_CN.md
@@ -22,6 +22,7 @@ Pulsar Flink 连接器使用 [Apache Pulsar](https://pulsar.apache.org) 和 [Apa
 | 1.10.x        | 2.5.x                            | [`release-1.10`](https://github.com/streamnative/pulsar-flink/tree/release-1.10) |
 | 1.11.x        | 2.6.x                            | [`release-1.11`](https://github.com/streamnative/pulsar-flink/tree/release-1.11) |
 | 1.12.x        | 2.7.x                            | [`release-1.12`](https://github.com/streamnative/pulsar-flink/tree/release-1.12) |
+| 1.13.x        | 2.8.x                            | [`release-1.13`](https://github.com/streamnative/pulsar-flink/tree/release-1.13) |
 
 
 > **说明**  


### PR DESCRIPTION
add Flink-v1.13.x in `Client` part, as below:
```
## Client

We change our project [version definition](doc/connector-version-definition.md), the Flink & Pulsar supporting matrix is here.

| Flink version | Pulsar client version (or above) | Connector branch                                                                 |
|:--------------|:---------------------------------|:---------------------------------------------------------------------------------|
| 1.9.x         | 2.5.x                            | [`release-1.9`](https://github.com/streamnative/pulsar-flink/tree/release-1.9)   |
| 1.10.x        | 2.5.x                            | [`release-1.10`](https://github.com/streamnative/pulsar-flink/tree/release-1.10) |
| 1.11.x        | 2.6.x                            | [`release-1.11`](https://github.com/streamnative/pulsar-flink/tree/release-1.11) |
| 1.12.x        | 2.7.x                            | [`release-1.12`](https://github.com/streamnative/pulsar-flink/tree/release-1.12) |
| 1.13.x        | 2.8.x                            | [`release-1.13`](https://github.com/streamnative/pulsar-flink/tree/release-1.13) |
```
