### PR TITLE
Correct README

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,8 +267,7 @@ FlinkPulsarSink<Person> sink = new FlinkPulsarSink(
     adminUrl,
     Optional.of(topic), // mandatory target topic or use `Optional.empty()` if sink to different topics for each record
     props,
-    pulsarSerialization,
-    PulsarSinkSemantic.AT_LEAST_ONCE
+    pulsarSerialization
 );
 
 stream.addSink(sink);

--- a/doc/README_CN.md
+++ b/doc/README_CN.md
@@ -265,8 +265,7 @@ FlinkPulsarSink<Person> sink = new FlinkPulsarSink(
     adminUrl,
     Optional.of(topic), // mandatory target topic or use `Optional.empty()` if sink to different topics for each record
     props,
-    pulsarSerialization,
-    PulsarSinkSemantic.AT_LEAST_ONCE
+    pulsarSerialization
 );
 
 stream.addSink(sink);


### PR DESCRIPTION
The unmatched `FlinkPulsarSink construct` is called in README
```
FlinkPulsarSink<Person> sink = new FlinkPulsarSink(
    serviceUrl,
    adminUrl,
    Optional.of(topic), // mandatory target topic or use `Optional.empty()` if sink to different topics for each record
    props,
    pulsarSerialization,
    PulsarSinkSemantic.AT_LEAST_ONCE
);
```