### PR TITLE
clean table name generation code

### DIFF
--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/table/PulsarDynamicTableFactory.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/table/PulsarDynamicTableFactory.java
@@ -106,7 +106,7 @@ public class PulsarDynamicTableFactory implements
             return createDynamicTableSinkUpsert(context);
         }
 
-        List<String> topics  = generateTopic(context, tableOptions) ;
+        List<String> topics = generateTopic(context, tableOptions);
         if (!topics.isEmpty()) {
             ((Configuration) tableOptions).set(TOPIC, Collections.singletonList(topics.get(0)));
         }
@@ -273,11 +273,11 @@ public class PulsarDynamicTableFactory implements
     // --------------------------------------------------------------------------------------------
 
     private List<String> generateTopic(Context context, ReadableConfig tableOptions) {
-        List<String> topics;
+        List<String> topics = null;
         final ObjectIdentifier table = context.getObjectIdentifier();
         if (PulsarCatalogSupport.isNativeFlinkDatabase(table.getDatabaseName())) {
             topics = tableOptions.getOptional(TOPIC).orElse(Collections.emptyList());
-        } else {
+        } else if (tableOptions.get(TOPIC_PATTERN) == null) {
             String rawTopic = table.getDatabaseName() + "/" + table.getObjectName();
             String topic = TopicName.get(rawTopic).toString();
             topics = Collections.singletonList(topic);
@@ -393,7 +393,7 @@ public class PulsarDynamicTableFactory implements
 
         String adminUrl = tableOptions.get(ADMIN_URL);
         String serverUrl = tableOptions.get(SERVICE_URL);
-        List<String> topics = tableOptions.get(TOPIC);
+        List<String> topics = tableOptions.getOptional(TOPIC).orElse(Collections.emptyList());
         String topicPattern = tableOptions.get(TOPIC_PATTERN);
 
         // Validate the option data type.

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/table/PulsarDynamicTableFactory.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/table/PulsarDynamicTableFactory.java
@@ -106,17 +106,9 @@ public class PulsarDynamicTableFactory implements
             return createDynamicTableSinkUpsert(context);
         }
 
-        List<String> topics = new ArrayList<>();
-        if (PulsarCatalogSupport.isNativeFlinkDatabase(context.getObjectIdentifier().getDatabaseName())) {
-            topics = tableOptions.get(TOPIC);
-            if (topics != null && !topics.isEmpty()) {
-                ((Configuration) tableOptions).set(TOPIC, Collections.singletonList(topics.get(0)));
-            }
-        } else {
-            final ObjectIdentifier table = context.getObjectIdentifier();
-            final String topic = TopicName.get(table.getDatabaseName() + "/" + table.getObjectName()).toString();
-            ((Configuration) tableOptions).set(TOPIC, Collections.singletonList(topic));
-            topics.add(topic);
+        List<String> topics  = generateTopic(context, tableOptions) ;
+        if (!topics.isEmpty()) {
+            ((Configuration) tableOptions).set(TOPIC, Collections.singletonList(topics.get(0)));
         }
 
         String adminUrl = tableOptions.get(ADMIN_URL);
@@ -184,23 +176,18 @@ public class PulsarDynamicTableFactory implements
             return createDynamicTableSourceUpsert(context);
         }
 
-        List<String> topics = new ArrayList<>();
+        List<String> topics = generateTopic(context, tableOptions);
+        if (!topics.isEmpty()) {
+            ((Configuration) tableOptions).set(TOPIC, Collections.singletonList(topics.get(0)));
+        }
+
+        // Native Flink Table can reference multiple topics with topicPattern
         String topicPattern = null;
         if (PulsarCatalogSupport.isNativeFlinkDatabase(context.getObjectIdentifier().getDatabaseName())) {
-            topics = tableOptions.get(TOPIC);
-            if (topics != null && !topics.isEmpty()) {
-                ((Configuration) tableOptions).set(TOPIC, Collections.singletonList(topics.get(0)));
-            }
-
             topicPattern = tableOptions.get(TOPIC_PATTERN);
-            if (topicPattern != null) {
-                ((Configuration) tableOptions).set(TOPIC_PATTERN, topicPattern);
-            }
-        } else {
-            final ObjectIdentifier table = context.getObjectIdentifier();
-            final String topic = TopicName.get(table.getDatabaseName() + "/" + table.getObjectName()).toString();
-            ((Configuration) tableOptions).set(TOPIC, Collections.singletonList(topic));
-            topics.add(topic);
+        }
+        if (topicPattern != null) {
+            ((Configuration) tableOptions).set(TOPIC_PATTERN, topicPattern);
         }
 
         String adminUrl = tableOptions.get(ADMIN_URL);
@@ -284,6 +271,20 @@ public class PulsarDynamicTableFactory implements
     }
 
     // --------------------------------------------------------------------------------------------
+
+    private List<String> generateTopic(Context context, ReadableConfig tableOptions) {
+        List<String> topics;
+        final ObjectIdentifier table = context.getObjectIdentifier();
+        if (PulsarCatalogSupport.isNativeFlinkDatabase(table.getDatabaseName())) {
+            topics = tableOptions.getOptional(TOPIC).orElse(Collections.emptyList());
+        } else {
+            String rawTopic = table.getDatabaseName() + "/" + table.getObjectName();
+            String topic = TopicName.get(rawTopic).toString();
+            topics = Collections.singletonList(topic);
+        }
+
+        return topics;
+    }
 
     private static Optional<DecodingFormat<DeserializationSchema<RowData>>> getKeyDecodingFormat(
             FactoryUtil.TableFactoryHelper helper) {

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/table/PulsarDynamicTableSource.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/table/PulsarDynamicTableSource.java
@@ -176,9 +176,9 @@ public class PulsarDynamicTableSource implements ScanTableSource, SupportsReadin
         this.metadataKeys = new ArrayList<>();
         this.watermarkStrategy = null;
         // Pulsar-specific attributes
-        Preconditions.checkArgument((topics != null && topicPattern == null) ||
-                        (topics == null && topicPattern != null),
-                "Either Topic or Topic Pattern must be set for source.");
+        Preconditions.checkArgument(((topics != null && !topics.isEmpty()) && topicPattern == null) ||
+                ((topics == null || topics.isEmpty()) && topicPattern != null),
+                "Only one of (Topic, Topic_Pattern) can be set for source.");
         this.topics = topics;
         this.topicPattern = topicPattern;
         this.adminUrl = adminUrl;

--- a/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/table/PulsarDynamicTableFactoryTest.java
+++ b/pulsar-flink-connector/src/test/java/org/apache/flink/streaming/connectors/pulsar/table/PulsarDynamicTableFactoryTest.java
@@ -222,7 +222,7 @@ public class PulsarDynamicTableFactoryTest extends TestLogger {
                 null,
                 SERVICE_URL,
                 ADMIN_URL,
-                null,
+                Collections.emptyList(),
                 TOPIC_REGEX,
                 PULSAR_SOURCE_PROPERTIES,
                 startupOptions


### PR DESCRIPTION
Based on @syhily's comment in PR #439,  refactoring the table name generation code by following the DRY rule for both source and sink generation