### PR TITLE
fix incorrect method getUseEarliestWhenDataLossAndRemoveKey

### DIFF
--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarOptions.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarOptions.java
@@ -67,7 +67,7 @@ public class PulsarOptions {
     public static final String OLD_STATE_VERSION = "old-state-version";
     public static final String FAIL_ON_DATA_LOSS_OPTION_KEY = "failOnDataLoss";
     public static final String USE_EARLIEST_WHEN_DATA_LOSS_OPTION_KEY =
-            "use-earliest-when-data-loss";
+            "useEarliestWhenDataLoss";
     public static final String SEND_DELAY_MILLISECONDS = "send-delay-millisecond";
 
     public static final String INSTRUCTION_FOR_FAIL_ON_DATA_LOSS_FALSE =

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/SourceSinkUtils.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/SourceSinkUtils.java
@@ -235,12 +235,15 @@ public class SourceSinkUtils {
     }
 
     public static boolean getUseEarliestWhenDataLossAndRemoveKey(Map<String, Object> readerConf) {
-        String failOnDataLossVal =
-                readerConf
-                        .getOrDefault(PulsarOptions.USE_EARLIEST_WHEN_DATA_LOSS_OPTION_KEY, "false")
-                        .toString();
+        String key = PulsarOptions.USE_EARLIEST_WHEN_DATA_LOSS_OPTION_KEY;
+        if (!readerConf.containsKey(key)) {
+            key = CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_HYPHEN, key);
+        }
+        String failOnDataLossVal = readerConf
+                .getOrDefault(key, "false")
+                .toString();
         final boolean value = Boolean.parseBoolean(failOnDataLossVal);
-        readerConf.remove(PulsarOptions.USE_EARLIEST_WHEN_DATA_LOSS_OPTION_KEY);
+        readerConf.remove(key);
         return value;
     }
 }


### PR DESCRIPTION
`pulsar.reader.use-earliest-when-data-loss` property has been transformed into `useEarliestWhenDataLoss` by method `getPulsarProperties` in `readerConf`.

So  methdo `getUseEarliestWhenDataLossAndRemoveKey` should get `useEarliestWhenDataLoss`  from readerConf instead of `use-earliest-when-data-loss`.