### PR TITLE
[486] Add protobuf jar in the shaded jar

### DIFF
--- a/pulsar-flink-sql-connector/pom.xml
+++ b/pulsar-flink-sql-connector/pom.xml
@@ -104,6 +104,7 @@ under the License.
 								<includes>
 									<include>io.streamnative.connectors:pulsar-flink-connector*</include>
 									<include>io.streamnative.connectors:flink-protobuf</include>
+									<include>com.google.protobuf:*</include>
 									<include>org.apache.pulsar:*</include>
 									<include>org.bouncycastle*:*</include>
 									<include>org.bouncycastle*:*</include>


### PR DESCRIPTION

Adding protobuf jar in the shaded jar.  For Issue 486 https://github.com/streamnative/pulsar-flink/issues/486