### PR TITLE
update protobuf version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ under the License.
 
 	<groupId>io.streamnative.connectors</groupId>
 	<artifactId>pulsar-flink-parent</artifactId>
-	<version>1.13.1.0</version>
+	<version>1.13.3.0</version>
 
 	<name>StreamNative :: Pulsar Flink Connector :: Root</name>
 	<packaging>pom</packaging>
@@ -91,8 +91,11 @@ under the License.
 		<slf4j.version>1.7.15</slf4j.version>
 
 		<!-- Protobuf support -->
-		<protobuf.version>3.11.4</protobuf.version>
+		<protobuf.version>3.16.1</protobuf.version>
 		<flink-protobuf.version>2.7.6</flink-protobuf.version>
+		<protobuf-plugin.version>3.11.4</protobuf-plugin.version>
+
+		<jaxb.version>2.3.0</jaxb.version>
 
 		<!-- Default scala versions, must be overwritten by build profiles, so we set something
 		invalid here -->

--- a/pulsar-flink-connector/pom.xml
+++ b/pulsar-flink-connector/pom.xml
@@ -84,6 +84,11 @@ under the License.
 			<version>${flink.version}</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>${jaxb.version}</version>
+		</dependency>
 
 		<!-- Test dependencies -->
 		<dependency>
@@ -234,7 +239,7 @@ under the License.
 			<plugin>
 				<groupId>com.github.os72</groupId>
 				<artifactId>protoc-jar-maven-plugin</artifactId>
-				<version>${protobuf.version}</version>
+				<version>${protobuf-plugin.version}</version>
 				<executions>
 					<execution>
 						<id>generate-protobuf-test-sources</id>


### PR DESCRIPTION
Due to the CVE: 
https://nvd.nist.gov/vuln/detail/CVE-2021-22569 

Reference the fix in Apache Pulsar:
https://github.com/apache/pulsar/pull/13695

Note:
I also tried to update the protobuf plugin (com.github.os72:protoc-jar-maven-plugin), but there's no newer release other than 3.11.4 at this time. https://mvnrepository.com/artifact/com.github.os72/protoc-jar-maven-plugin 