### PR TITLE
Connector support pulsar cluster with both JWT and TLS auth

### DIFF
--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/catalog/PulsarCatalog.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/catalog/PulsarCatalog.java
@@ -70,6 +70,8 @@ public class PulsarCatalog extends GenericInMemoryCatalog {
 
     private final String authParams;
 
+    private final String tlsTrustCertsFilePath;
+
     private final String tenant;
 
     private PulsarCatalogSupport catalogSupport;
@@ -85,13 +87,15 @@ public class PulsarCatalog extends GenericInMemoryCatalog {
             String database,
             String tenant,
             @Nullable String authPlugin,
-            @Nullable String authParams) {
+            @Nullable String authParams,
+            @Nullable String tlsTrustCertsFilePath) {
         super(catalogName, database);
         this.adminUrl = adminUrl;
         this.serviceUrl = serviceUrl;
         this.authPlugin = authPlugin;
         this.authParams = authParams;
         this.tenant = tenant;
+        this.tlsTrustCertsFilePath = tlsTrustCertsFilePath;
 
         log.info("Created Pulsar Catalog {}", catalogName);
     }
@@ -108,6 +112,7 @@ public class PulsarCatalog extends GenericInMemoryCatalog {
                 final ClientConfigurationData clientConf = new ClientConfigurationData();
                 clientConf.setAuthPluginClassName(this.authPlugin);
                 clientConf.setAuthParams(this.authParams);
+                clientConf.setTlsTrustCertsFilePath(this.tlsTrustCertsFilePath);
                 clientConf.setServiceUrl(serviceUrl);
                 catalogSupport =
                         new PulsarCatalogSupport(

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/catalog/PulsarCatalogFactory.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/catalog/PulsarCatalogFactory.java
@@ -36,6 +36,7 @@ import static org.apache.flink.streaming.connectors.pulsar.catalog.PulsarCatalog
 import static org.apache.flink.streaming.connectors.pulsar.catalog.PulsarCatalogFactoryOptions.IDENTIFIER;
 import static org.apache.flink.streaming.connectors.pulsar.catalog.PulsarCatalogFactoryOptions.PULSAR_VERSION;
 import static org.apache.flink.streaming.connectors.pulsar.catalog.PulsarCatalogFactoryOptions.SERVICE_URL;
+import static org.apache.flink.streaming.connectors.pulsar.catalog.PulsarCatalogFactoryOptions.TLS_TRUSTCERTS_FILE_PATH;
 
 /** Pulsar {@CatalogFactory}. */
 public class PulsarCatalogFactory implements CatalogFactory {
@@ -57,7 +58,8 @@ public class PulsarCatalogFactory implements CatalogFactory {
                 helper.getOptions().get(DEFAULT_DATABASE),
                 helper.getOptions().get(CATALOG_TENANT),
                 helper.getOptions().get(AUTH_PLUGIN),
-                helper.getOptions().get(AUTH_PARAMS));
+                helper.getOptions().get(AUTH_PARAMS),
+                helper.getOptions().get(TLS_TRUSTCERTS_FILE_PATH));
     }
 
     @Override
@@ -77,7 +79,7 @@ public class PulsarCatalogFactory implements CatalogFactory {
         options.add(AUTH_PARAMS);
         options.add(DEFAULT_PARTITIONS);
         options.add(PULSAR_VERSION);
-
+        options.add(TLS_TRUSTCERTS_FILE_PATH);
         // TODO: investigate if need to provide default table options
 
         return options;

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/catalog/PulsarCatalogFactoryOptions.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/catalog/PulsarCatalogFactoryOptions.java
@@ -73,6 +73,11 @@ public final class PulsarCatalogFactoryOptions {
             ConfigOptions.key("pulsar-version")
                     .stringType()
                     .defaultValue(PulsarVersion.getVersion());
+    public static final ConfigOption<String> TLS_TRUSTCERTS_FILE_PATH =
+            ConfigOptions.key("catalog-tls-trustcerts-filepath")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("tls trust certs file path config");
 
     private PulsarCatalogFactoryOptions() {}
 }

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/catalog/util/PulsarCatalogSupport.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/catalog/util/PulsarCatalogSupport.java
@@ -256,6 +256,14 @@ public class PulsarCatalogSupport {
                     authParams);
         }
 
+        String tlsTrustCertFilePath =
+                pulsarMetadataReader.getClientConf().getTlsTrustCertsFilePath();
+        if (tlsTrustCertFilePath != null && !tlsTrustCertFilePath.isEmpty()) {
+            enrichedTableOptions.put(
+                    PulsarTableOptions.PROPERTIES_PREFIX + PulsarOptions.TLS_TRUSTCERTS_FILEPATH,
+                    tlsTrustCertFilePath);
+        }
+
         if (tableOptions != null) {
             // table options could overwrite the default options provided above
             enrichedTableOptions.putAll(tableOptions);

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarClientUtils.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarClientUtils.java
@@ -62,6 +62,7 @@ public class PulsarClientUtils {
             clientConf.setAuthParams(properties.getProperty(PulsarOptions.AUTH_PARAMS_KEY));
             clientConf.setAuthPluginClassName(
                     properties.getProperty(PulsarOptions.AUTH_PLUGIN_CLASSNAME_KEY));
+            clientConf.setTlsTrustCertsFilePath(PulsarOptions.TLS_TRUSTCERTS_FILEPATH);
         }
         return clientConf;
     }

--- a/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarOptions.java
+++ b/pulsar-flink-connector/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarOptions.java
@@ -98,4 +98,5 @@ public class PulsarOptions {
 
     public static final String AUTH_PARAMS_KEY = "auth-params";
     public static final String AUTH_PLUGIN_CLASSNAME_KEY = "auth-plugin-classname";
+    public static final String TLS_TRUSTCERTS_FILEPATH = "tls-trustcerts-filepath";
 }


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

when pulsar cluster start up with JWT auth and TLS for transport encryption. Connector cannot configure both authentication methods at the same time。

### Modifications

I  have provided a simple patch to fix this, add a config 'catalog-tls-trustcert-filepath' like 'auth-plugin'.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation
related config key as below:

Catalog : catalog-tls-trustcerts-filepath
DDL: properties.tls-trustcerts-filepath

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

